### PR TITLE
[Task] slack 환경 관리용 EKS workflow 추가

### DIFF
--- a/.github/workflows/orchestrate-environment.yml
+++ b/.github/workflows/orchestrate-environment.yml
@@ -1,0 +1,102 @@
+name: Orchestrate Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Requested operation"
+        required: true
+        type: choice
+        options:
+          - start
+          - stop
+      slack_user_id:
+        description: "Slack user ID"
+        required: true
+        type: string
+      namespace:
+        description: "Namespace mapped to the Slack user"
+        required: true
+        type: string
+      request_id:
+        description: "Unique request identifier"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: environment-orchestration
+  cancel-in-progress: false
+
+jobs:
+  orchestrate:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      AWS_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME }}
+      TERRAFORM_STATE_BUCKET: ${{ vars.TERRAFORM_STATE_BUCKET }}
+      TERRAFORM_STATE_REGION: ${{ vars.TERRAFORM_STATE_REGION }}
+      INFRA_TERRAFORM_STATE_KEY: ${{ vars.INFRA_TERRAFORM_STATE_KEY }}
+      PLATFORM_TERRAFORM_STATE_KEY: ${{ vars.PLATFORM_TERRAFORM_STATE_KEY }}
+      PLATFORM_INFRA_STATE_BUCKET: ${{ vars.PLATFORM_INFRA_STATE_BUCKET }}
+      PLATFORM_INFRA_STATE_REGION: ${{ vars.PLATFORM_INFRA_STATE_REGION }}
+      ORCHESTRATION_STATE_BUCKET: ${{ vars.ORCHESTRATION_STATE_BUCKET }}
+      ORCHESTRATION_STATE_KEY: ${{ vars.ORCHESTRATION_STATE_KEY }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.11.4
+
+      - name: Install Python dependencies
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install boto3
+
+      - name: Validate orchestration configuration
+        run: |
+          set -euo pipefail
+
+          required_vars=(
+            AWS_REGION
+            AWS_ROLE_TO_ASSUME
+            TERRAFORM_STATE_BUCKET
+            ORCHESTRATION_STATE_BUCKET
+            ORCHESTRATION_STATE_KEY
+          )
+
+          for name in "${required_vars[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is required for orchestration."
+              exit 1
+            fi
+          done
+
+      - name: Configure AWS credentials with OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          role-session-name: github-actions-eks-orchestrator
+
+      - name: Run orchestration
+        run: |
+          set -euo pipefail
+          python scripts/manage_environment.py \
+            --operation "${{ github.event.inputs.operation }}" \
+            --slack-user-id "${{ github.event.inputs.slack_user_id }}" \
+            --namespace "${{ github.event.inputs.namespace }}" \
+            --request-id "${{ github.event.inputs.request_id }}"

--- a/scripts/manage_environment.py
+++ b/scripts/manage_environment.py
@@ -1,0 +1,273 @@
+import argparse
+import copy
+import datetime as dt
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INFRA_DIR = REPO_ROOT / "environments" / "infra"
+PLATFORM_DIR = REPO_ROOT / "environments" / "platform"
+
+
+def default_state() -> dict[str, Any]:
+    return {
+        "infra_status": "stopped",
+        "active_users": {},
+        "active_namespaces": [],
+        "pending_operation": None,
+        "last_error": None,
+        "updated_at": None,
+    }
+
+
+def utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class S3StateStore:
+    def __init__(self, bucket: str, key: str, region_name: str | None = None):
+        self.bucket = bucket
+        self.key = key
+        self.region_name = region_name
+
+    @property
+    def client(self):
+        import boto3
+
+        return boto3.client("s3", region_name=self.region_name)
+
+    def read_state(self) -> dict[str, Any]:
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=self.key)
+        except Exception as exc:
+            error_response = getattr(exc, "response", {}) or {}
+            error_code = error_response.get("Error", {}).get("Code")
+            if error_code in {"NoSuchKey", "404", "NoSuchBucket"}:
+                return default_state()
+            raise
+
+        body = response["Body"].read().decode("utf-8")
+        if not body.strip():
+            return default_state()
+
+        state = default_state()
+        state.update(json.loads(body))
+        return state
+
+    def write_state(self, state: dict[str, Any]) -> None:
+        self.client.put_object(
+            Bucket=self.bucket,
+            Key=self.key,
+            Body=json.dumps(state, ensure_ascii=False, sort_keys=True).encode("utf-8"),
+            ContentType="application/json",
+        )
+
+
+class TerraformRunner:
+    def __init__(
+        self,
+        aws_region: str,
+        terraform_state_bucket: str,
+        terraform_state_region: str,
+        infra_state_key: str = "infra/terraform.tfstate",
+        platform_state_key: str = "platform/terraform.tfstate",
+        platform_infra_state_bucket: str | None = None,
+        platform_infra_state_region: str | None = None,
+    ):
+        self.aws_region = aws_region
+        self.terraform_state_bucket = terraform_state_bucket
+        self.terraform_state_region = terraform_state_region
+        self.infra_state_key = infra_state_key
+        self.platform_state_key = platform_state_key
+        self.platform_infra_state_bucket = platform_infra_state_bucket or terraform_state_bucket
+        self.platform_infra_state_region = platform_infra_state_region or terraform_state_region
+
+    def _run(self, args: list[str], cwd: Path) -> None:
+        subprocess.run(args, cwd=cwd, check=True)
+
+    def _init(self, cwd: Path, state_key: str) -> None:
+        self._run(
+            [
+                "terraform",
+                "init",
+                "-input=false",
+                f"-backend-config=bucket={self.terraform_state_bucket}",
+                f"-backend-config=key={state_key}",
+                f"-backend-config=region={self.terraform_state_region}",
+            ],
+            cwd=cwd,
+        )
+
+    def apply_infra(self) -> None:
+        self._init(INFRA_DIR, self.infra_state_key)
+        self._run(["terraform", "apply", "-input=false", "-auto-approve"], cwd=INFRA_DIR)
+
+    def apply_platform(self, namespaces: list[str]) -> None:
+        self._init(PLATFORM_DIR, self.platform_state_key)
+        self._run(
+            [
+                "terraform",
+                "apply",
+                "-input=false",
+                "-auto-approve",
+                f"-var=infra_state_bucket_name={self.platform_infra_state_bucket}",
+                f"-var=infra_state_region={self.platform_infra_state_region}",
+                f"-var=team_names={json.dumps(namespaces)}",
+            ],
+            cwd=PLATFORM_DIR,
+        )
+
+    def destroy_platform(self) -> None:
+        self._init(PLATFORM_DIR, self.platform_state_key)
+        self._run(
+            [
+                "terraform",
+                "destroy",
+                "-input=false",
+                "-auto-approve",
+                f"-var=infra_state_bucket_name={self.platform_infra_state_bucket}",
+                f"-var=infra_state_region={self.platform_infra_state_region}",
+            ],
+            cwd=PLATFORM_DIR,
+        )
+
+    def destroy_infra(self) -> None:
+        self._init(INFRA_DIR, self.infra_state_key)
+        self._run(["terraform", "destroy", "-input=false", "-auto-approve"], cwd=INFRA_DIR)
+
+
+class EnvironmentOrchestrator:
+    def __init__(self, state_store: Any, terraform_runner: Any):
+        self.state_store = state_store
+        self.terraform_runner = terraform_runner
+
+    def run(self, operation: str, slack_user_id: str, namespace: str, request_id: str) -> dict[str, Any]:
+        current_state = self._normalize_state(self.state_store.read_state())
+        pending_state = copy.deepcopy(current_state)
+        pending_state["pending_operation"] = {
+            "operation": operation,
+            "slack_user_id": slack_user_id,
+            "namespace": namespace,
+            "request_id": request_id,
+            "updated_at": utc_now_iso(),
+        }
+        self.state_store.write_state(pending_state)
+
+        try:
+            if operation == "start":
+                next_state = self._handle_start(current_state, slack_user_id, namespace)
+            elif operation == "stop":
+                next_state = self._handle_stop(current_state, slack_user_id)
+            else:
+                raise ValueError(f"Unsupported operation: {operation}")
+        except Exception as exc:
+            failed_state = copy.deepcopy(current_state)
+            failed_state["pending_operation"] = None
+            failed_state["last_error"] = {
+                "request_id": request_id,
+                "operation": operation,
+                "slack_user_id": slack_user_id,
+                "namespace": namespace,
+                "message": str(exc),
+                "updated_at": utc_now_iso(),
+            }
+            self.state_store.write_state(failed_state)
+            raise
+
+        next_state["pending_operation"] = None
+        next_state["last_error"] = None
+        next_state["updated_at"] = utc_now_iso()
+        self.state_store.write_state(next_state)
+        return next_state
+
+    def _normalize_state(self, state: dict[str, Any]) -> dict[str, Any]:
+        normalized = default_state()
+        normalized.update(state or {})
+        normalized["active_users"] = dict(normalized.get("active_users") or {})
+        normalized["active_namespaces"] = sorted(set(normalized.get("active_namespaces") or []))
+        return normalized
+
+    def _handle_start(self, current_state: dict[str, Any], slack_user_id: str, namespace: str) -> dict[str, Any]:
+        next_state = copy.deepcopy(current_state)
+        next_state["active_users"][slack_user_id] = namespace
+        next_state["active_namespaces"] = sorted(set(next_state["active_users"].values()))
+
+        should_apply_infra = current_state.get("infra_status") != "running" or not current_state["active_users"]
+        if should_apply_infra:
+            self.terraform_runner.apply_infra()
+
+        if should_apply_infra or next_state["active_users"] != current_state["active_users"]:
+            self.terraform_runner.apply_platform(next_state["active_namespaces"])
+
+        next_state["infra_status"] = "running"
+        return next_state
+
+    def _handle_stop(self, current_state: dict[str, Any], slack_user_id: str) -> dict[str, Any]:
+        next_state = copy.deepcopy(current_state)
+        next_state["active_users"].pop(slack_user_id, None)
+        next_state["active_namespaces"] = sorted(set(next_state["active_users"].values()))
+
+        if current_state.get("infra_status") != "running":
+            next_state["infra_status"] = "stopped"
+            return next_state
+
+        if not next_state["active_users"]:
+            self.terraform_runner.destroy_platform()
+            self.terraform_runner.destroy_infra()
+            next_state["infra_status"] = "stopped"
+            return next_state
+
+        if next_state["active_users"] != current_state["active_users"]:
+            self.terraform_runner.apply_platform(next_state["active_namespaces"])
+
+        next_state["infra_status"] = "running"
+        return next_state
+
+
+def build_runner_from_env() -> TerraformRunner:
+    return TerraformRunner(
+        aws_region=os.environ.get("AWS_REGION", "ap-northeast-2"),
+        terraform_state_bucket=os.environ["TERRAFORM_STATE_BUCKET"],
+        terraform_state_region=os.environ.get("TERRAFORM_STATE_REGION", os.environ.get("AWS_REGION", "ap-northeast-2")),
+        infra_state_key=os.environ.get("INFRA_TERRAFORM_STATE_KEY", "infra/terraform.tfstate"),
+        platform_state_key=os.environ.get("PLATFORM_TERRAFORM_STATE_KEY", "platform/terraform.tfstate"),
+        platform_infra_state_bucket=os.environ.get("PLATFORM_INFRA_STATE_BUCKET"),
+        platform_infra_state_region=os.environ.get("PLATFORM_INFRA_STATE_REGION"),
+    )
+
+
+def build_state_store_from_env() -> S3StateStore:
+    return S3StateStore(
+        bucket=os.environ["ORCHESTRATION_STATE_BUCKET"],
+        key=os.environ["ORCHESTRATION_STATE_KEY"],
+        region_name=os.environ.get("AWS_REGION", "ap-northeast-2"),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage infra/platform environment lifecycle.")
+    parser.add_argument("--operation", required=True, choices=["start", "stop"])
+    parser.add_argument("--slack-user-id", required=True)
+    parser.add_argument("--namespace", required=True)
+    parser.add_argument("--request-id", required=True)
+    args = parser.parse_args()
+
+    orchestrator = EnvironmentOrchestrator(
+        state_store=build_state_store_from_env(),
+        terraform_runner=build_runner_from_env(),
+    )
+    result = orchestrator.run(
+        operation=args.operation,
+        slack_user_id=args.slack_user_id,
+        namespace=args.namespace,
+        request_id=args.request_id,
+    )
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_manage_environment.py
+++ b/tests/test_manage_environment.py
@@ -1,0 +1,186 @@
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "manage_environment.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("manage_environment", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeStateStore:
+    def __init__(self, initial_state):
+        self.state = copy.deepcopy(initial_state)
+        self.writes = []
+
+    def read_state(self):
+        return copy.deepcopy(self.state)
+
+    def write_state(self, state):
+        snapshot = copy.deepcopy(state)
+        self.writes.append(snapshot)
+        self.state = snapshot
+
+
+class RecordingTerraformRunner:
+    def __init__(self, fail_on=None):
+        self.fail_on = fail_on
+        self.calls = []
+
+    def apply_infra(self):
+        self.calls.append(("apply_infra", None))
+        if self.fail_on == "apply_infra":
+            raise RuntimeError("infra apply failed")
+
+    def apply_platform(self, namespaces):
+        self.calls.append(("apply_platform", list(namespaces)))
+        if self.fail_on == "apply_platform":
+            raise RuntimeError("platform apply failed")
+
+    def destroy_platform(self):
+        self.calls.append(("destroy_platform", None))
+        if self.fail_on == "destroy_platform":
+            raise RuntimeError("platform destroy failed")
+
+    def destroy_infra(self):
+        self.calls.append(("destroy_infra", None))
+        if self.fail_on == "destroy_infra":
+            raise RuntimeError("infra destroy failed")
+
+
+class OrchestratorTests(unittest.TestCase):
+    def test_first_start_applies_infra_then_platform_and_records_state(self):
+        module = load_module()
+        state_store = FakeStateStore(module.default_state())
+        terraform_runner = RecordingTerraformRunner()
+        orchestrator = module.EnvironmentOrchestrator(state_store=state_store, terraform_runner=terraform_runner)
+
+        result = orchestrator.run(
+            operation="start",
+            slack_user_id="U123",
+            namespace="team-a",
+            request_id="req-1",
+        )
+
+        self.assertEqual(terraform_runner.calls, [("apply_infra", None), ("apply_platform", ["team-a"])])
+        self.assertEqual(result["infra_status"], "running")
+        self.assertEqual(result["active_users"], {"U123": "team-a"})
+        self.assertEqual(result["active_namespaces"], ["team-a"])
+        self.assertEqual(state_store.writes[0]["pending_operation"]["operation"], "start")
+        self.assertIsNone(state_store.writes[-1]["pending_operation"])
+
+    def test_second_start_only_expands_platform_namespaces(self):
+        module = load_module()
+        initial_state = module.default_state()
+        initial_state.update(
+            {
+                "infra_status": "running",
+                "active_users": {"U123": "team-a"},
+                "active_namespaces": ["team-a"],
+            }
+        )
+        state_store = FakeStateStore(initial_state)
+        terraform_runner = RecordingTerraformRunner()
+        orchestrator = module.EnvironmentOrchestrator(state_store=state_store, terraform_runner=terraform_runner)
+
+        result = orchestrator.run(
+            operation="start",
+            slack_user_id="U456",
+            namespace="team-b",
+            request_id="req-2",
+        )
+
+        self.assertEqual(terraform_runner.calls, [("apply_platform", ["team-a", "team-b"])])
+        self.assertEqual(result["active_users"], {"U123": "team-a", "U456": "team-b"})
+        self.assertEqual(result["active_namespaces"], ["team-a", "team-b"])
+
+    def test_stop_with_remaining_users_reapplies_platform_subset(self):
+        module = load_module()
+        initial_state = module.default_state()
+        initial_state.update(
+            {
+                "infra_status": "running",
+                "active_users": {"U123": "team-a", "U456": "team-b"},
+                "active_namespaces": ["team-a", "team-b"],
+            }
+        )
+        state_store = FakeStateStore(initial_state)
+        terraform_runner = RecordingTerraformRunner()
+        orchestrator = module.EnvironmentOrchestrator(state_store=state_store, terraform_runner=terraform_runner)
+
+        result = orchestrator.run(
+            operation="stop",
+            slack_user_id="U123",
+            namespace="team-a",
+            request_id="req-3",
+        )
+
+        self.assertEqual(terraform_runner.calls, [("apply_platform", ["team-b"])])
+        self.assertEqual(result["infra_status"], "running")
+        self.assertEqual(result["active_users"], {"U456": "team-b"})
+        self.assertEqual(result["active_namespaces"], ["team-b"])
+
+    def test_last_stop_destroys_platform_then_infra(self):
+        module = load_module()
+        initial_state = module.default_state()
+        initial_state.update(
+            {
+                "infra_status": "running",
+                "active_users": {"U123": "team-a"},
+                "active_namespaces": ["team-a"],
+            }
+        )
+        state_store = FakeStateStore(initial_state)
+        terraform_runner = RecordingTerraformRunner()
+        orchestrator = module.EnvironmentOrchestrator(state_store=state_store, terraform_runner=terraform_runner)
+
+        result = orchestrator.run(
+            operation="stop",
+            slack_user_id="U123",
+            namespace="team-a",
+            request_id="req-4",
+        )
+
+        self.assertEqual(terraform_runner.calls, [("destroy_platform", None), ("destroy_infra", None)])
+        self.assertEqual(result["infra_status"], "stopped")
+        self.assertEqual(result["active_users"], {})
+        self.assertEqual(result["active_namespaces"], [])
+
+    def test_failure_keeps_last_success_state_and_records_last_error(self):
+        module = load_module()
+        initial_state = module.default_state()
+        initial_state.update(
+            {
+                "infra_status": "running",
+                "active_users": {"U123": "team-a"},
+                "active_namespaces": ["team-a"],
+            }
+        )
+        state_store = FakeStateStore(initial_state)
+        terraform_runner = RecordingTerraformRunner(fail_on="apply_platform")
+        orchestrator = module.EnvironmentOrchestrator(state_store=state_store, terraform_runner=terraform_runner)
+
+        with self.assertRaisesRegex(RuntimeError, "platform apply failed"):
+            orchestrator.run(
+                operation="start",
+                slack_user_id="U456",
+                namespace="team-b",
+                request_id="req-5",
+            )
+
+        self.assertEqual(state_store.state["active_users"], {"U123": "team-a"})
+        self.assertEqual(state_store.state["active_namespaces"], ["team-a"])
+        self.assertIsNone(state_store.state["pending_operation"])
+        self.assertEqual(state_store.state["last_error"]["request_id"], "req-5")
+        self.assertIn("platform apply failed", state_store.state["last_error"]["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Slack의 environment-manager 봇이 호출할 workflow를 추가했습니다.
- start/stop 요청에 따라 infra/platform apply 또는 destroy를 수행하는 Python 스크립트를 추가했습니다.
- S3 상태 파일 기반 상태 관리, 단위 테스트를 함께 추가했습니다.

## 기대 동작
- environment-manager가 GitHub App으로 이 workflow를 호출할 수 있습니다.
- `/start_dev` 호출 시 활성 사용자가 없으면 infra와 platform을 생성합니다.
- `/stop_dev` 호출 시 마지막 사용자라면 bootstrap을 제외한 환경을 제거합니다.
- 상태 파일은 `infra_status, active_users, active_namespaces, pending_operation, last_error, updated_at를 유지합니다.