### PR TITLE
[Chore] 환경 일관성 추가

### DIFF
--- a/bootstrap/terraform.tfvars
+++ b/bootstrap/terraform.tfvars
@@ -1,10 +1,10 @@
-project_name = "eks-security-infra"
+project_name = "eks-secure-infra"
 environment  = "bootstrap"
 aws_region   = "ap-northeast-2"
 owner        = "K8RVIS"
 
 # Replace with a globally unique bucket name before running terraform apply.
-tfstate_bucket_name = "eks-security-infra-tfstate-example"
+tfstate_bucket_name = "eks-secure-infra-tfstate"
 
 github_oidc_url = "https://token.actions.githubusercontent.com"
 
@@ -13,6 +13,6 @@ github_oidc_client_ids = [
 ]
 
 default_tags = {
-  Repository = "eks-security-infra"
+  Repository = "eks-secure-infra"
   ManagedBy  = "terraform"
 }

--- a/bootstrap/tests/bootstrap.tftest.hcl
+++ b/bootstrap/tests/bootstrap.tftest.hcl
@@ -1,15 +1,15 @@
 variables {
-  project_name        = "eks-security-infra"
+  project_name        = "eks-secure-infra"
   environment         = "bootstrap"
   aws_region          = "ap-northeast-2"
   owner               = "K8RVIS"
-  tfstate_bucket_name = "eks-security-infra-tfstate-example"
+  tfstate_bucket_name = "eks-secure-infra-tfstate"
   github_oidc_url     = "https://token.actions.githubusercontent.com"
   github_oidc_client_ids = [
     "sts.amazonaws.com",
   ]
   default_tags = {
-    Repository = "eks-security-infra"
+    Repository = "eks-secure-infra"
     ManagedBy  = "terraform"
   }
 }

--- a/environments/dev/.terraform.lock.hcl
+++ b/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -1,4 +1,4 @@
-project_name = "eks-security-infra"
+project_name = "eks-secure-infra"
 environment  = "dev"
 aws_region   = "ap-northeast-2"
 owner        = "K8RVIS"
@@ -23,7 +23,7 @@ private_subnet_cidrs = [
 fck_nat_instance_type = "t4g.nano"
 
 default_tags = {
-  Repository = "eks-security-infra"
+  Repository = "eks-secure-infra"
   ManagedBy  = "terraform"
 }
 

--- a/environments/infra/terraform.tfvars
+++ b/environments/infra/terraform.tfvars
@@ -1,4 +1,4 @@
-project_name = "eks-security-infra"
+project_name = "eks-secure-infra"
 environment  = "dev"
 aws_region   = "ap-northeast-2"
 owner        = "K8RVIS"
@@ -23,7 +23,7 @@ private_subnet_cidrs = [
 fck_nat_instance_type = "t4g.nano"
 
 default_tags = {
-  Repository = "eks-security-infra"
+  Repository = "eks-secure-infra"
   ManagedBy  = "terraform"
 }
 

--- a/environments/platform/terraform.tfvars
+++ b/environments/platform/terraform.tfvars
@@ -1,9 +1,9 @@
-project_name = "eks-security-infra"
+project_name = "eks-secure-infra"
 environment  = "dev"
 aws_region   = "ap-northeast-2"
 
 # Replace with the bootstrap tfstate bucket name before running plan/apply.
-infra_state_bucket_name = "eks-security-infra-tfstate-example"
+infra_state_bucket_name = "eks-secure-infra-tfstate"
 infra_state_key         = "infra/terraform.tfstate"
 infra_state_region      = "ap-northeast-2"
 
@@ -11,4 +11,4 @@ metrics_server_chart_version = "3.13.0"
 ingress_nginx_chart_version  = "4.14.1"
 argocd_chart_version         = "9.4.17"
 argocd_apps_chart_version    = "2.0.3"
-gitops_repo_url              = "https://github.com/K8RVIS/eks-security-infra.git"
+gitops_repo_url              = "https://github.com/K8RVIS/eks-secure-infra.git"

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -104,7 +104,7 @@ variable "argocd_project_name" {
 variable "gitops_repo_url" {
   description = "Git repository URL that ArgoCD applications will watch."
   type        = string
-  default     = "https://github.com/K8RVIS/eks-security-infra.git"
+  default     = "https://github.com/K8RVIS/eks-secure-infra.git"
 }
 
 variable "gitops_target_revision" {

--- a/modules/argocd/.terraform.lock.hcl
+++ b/modules/argocd/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "3.1.1"
+  hashes = [
+    "h1:47CqNwkxctJtL/N/JuEj+8QMg8mRNI/NWeKO5/ydfZU=",
+    "zh:1a6d5ce931708aec29d1f3d9e360c2a0c35ba5a54d03eeaff0ce3ca597cd0275",
+    "zh:3411919ba2a5941801e677f0fea08bdd0ae22ba3c9ce3309f55554699e06524a",
+    "zh:81b36138b8f2320dc7f877b50f9e38f4bc614affe68de885d322629dd0d16a29",
+    "zh:95a2a0a497a6082ee06f95b38bd0f0d6924a65722892a856cfd914c0d117f104",
+    "zh:9d3e78c2d1bb46508b972210ad706dd8c8b106f8b206ecf096cd211c54f46990",
+    "zh:a79139abf687387a6efdbbb04289a0a8e7eaca2bd91cdc0ce68ea4f3286c2c34",
+    "zh:aaa8784be125fbd50c48d84d6e171d3fb6ef84a221dbc5165c067ce05faab4c8",
+    "zh:afecd301f469975c9d8f350cc482fe656e082b6ab0f677d1a816c3c615837cc1",
+    "zh:c54c22b18d48ff9053d899d178d9ffef7d9d19785d9bf310a07d648b7aac075b",
+    "zh:db2eefd55aea48e73384a555c72bac3f7d428e24147bedb64e1a039398e5b903",
+    "zh:ee61666a233533fd2be971091cecc01650561f1585783c381b6f6e8a390198a4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/modules/argocd/tests/gitops-entrypoint.tftest.hcl
+++ b/modules/argocd/tests/gitops-entrypoint.tftest.hcl
@@ -5,7 +5,7 @@ mock_provider "helm" {
 variables {
   argocd_chart_version           = "9.4.17"
   argocd_apps_chart_version      = "2.0.3"
-  gitops_repo_url                = "https://github.com/K8RVIS/eks-security-infra.git"
+  gitops_repo_url                = "https://github.com/K8RVIS/eks-secure-infra.git"
   gitops_target_revision         = "main"
   gitops_applications_base_path = "manifests/overlays"
   team_names                     = ["team-a", "team-b", "team-c", "team-d"]
@@ -45,7 +45,7 @@ run "plan_deploys_argocd_and_team_applications" {
   }
 
   assert {
-    condition     = strcontains(join("", helm_release.argocd_apps.values), "\"repoURL\": \"https://github.com/K8RVIS/eks-security-infra.git\"")
+    condition     = strcontains(join("", helm_release.argocd_apps.values), "\"repoURL\": \"https://github.com/K8RVIS/eks-secure-infra.git\"")
     error_message = "ArgoCD applications must target the configured GitOps repository."
   }
 

--- a/modules/eks/.terraform.lock.hcl
+++ b/modules/eks/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/eks/tests/minimal-cluster.tftest.hcl
+++ b/modules/eks/tests/minimal-cluster.tftest.hcl
@@ -9,7 +9,7 @@ provider "aws" {
 }
 
 variables {
-  project_name       = "eks-security-infra"
+  project_name       = "eks-secure-infra"
   environment        = "dev"
   owner              = "K8RVIS"
   cluster_subnet_ids = ["subnet-private-a", "subnet-private-b"]
@@ -26,7 +26,7 @@ variables {
   }
 
   default_tags = {
-    Repository = "eks-security-infra"
+    Repository = "eks-secure-infra"
     ManagedBy  = "terraform"
   }
 }
@@ -35,7 +35,7 @@ run "plan_builds_minimal_eks_cluster" {
   command = plan
 
   assert {
-    condition     = aws_eks_cluster.this.name == "eks-security-infra-dev"
+    condition     = aws_eks_cluster.this.name == "eks-secure-infra-dev"
     error_message = "EKS cluster name must follow the project-environment naming convention."
   }
 

--- a/modules/k8s-base/.terraform.lock.hcl
+++ b/modules/k8s-base/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "3.1.1"
+  hashes = [
+    "h1:47CqNwkxctJtL/N/JuEj+8QMg8mRNI/NWeKO5/ydfZU=",
+    "zh:1a6d5ce931708aec29d1f3d9e360c2a0c35ba5a54d03eeaff0ce3ca597cd0275",
+    "zh:3411919ba2a5941801e677f0fea08bdd0ae22ba3c9ce3309f55554699e06524a",
+    "zh:81b36138b8f2320dc7f877b50f9e38f4bc614affe68de885d322629dd0d16a29",
+    "zh:95a2a0a497a6082ee06f95b38bd0f0d6924a65722892a856cfd914c0d117f104",
+    "zh:9d3e78c2d1bb46508b972210ad706dd8c8b106f8b206ecf096cd211c54f46990",
+    "zh:a79139abf687387a6efdbbb04289a0a8e7eaca2bd91cdc0ce68ea4f3286c2c34",
+    "zh:aaa8784be125fbd50c48d84d6e171d3fb6ef84a221dbc5165c067ce05faab4c8",
+    "zh:afecd301f469975c9d8f350cc482fe656e082b6ab0f677d1a816c3c615837cc1",
+    "zh:c54c22b18d48ff9053d899d178d9ffef7d9d19785d9bf310a07d648b7aac075b",
+    "zh:db2eefd55aea48e73384a555c72bac3f7d428e24147bedb64e1a039398e5b903",
+    "zh:ee61666a233533fd2be971091cecc01650561f1585783c381b6f6e8a390198a4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/modules/namespaces/.terraform.lock.hcl
+++ b/modules/namespaces/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "3.0.1"
+  hashes = [
+    "h1:P0c8knzZnouTNFIRij8IS7+pqd0OKaFDYX0j4GRsiqo=",
+    "zh:02d55b0b2238fd17ffa12d5464593864e80f402b90b31f6e1bd02249b9727281",
+    "zh:20b93a51bfeed82682b3c12f09bac3031f5bdb4977c47c97a042e4df4fb2f9ba",
+    "zh:6e14486ecfaee38c09ccf33d4fdaf791409f90795c1b66e026c226fad8bc03c7",
+    "zh:8d0656ff422df94575668e32c310980193fccb1c28117e5c78dd2d4050a760a6",
+    "zh:9795119b30ec0c1baa99a79abace56ac850b6e6fbce60e7f6067792f6eb4b5f4",
+    "zh:b388c87acc40f6bd9620f4e23f01f3c7b41d9b88a68d5255dec0a72f0bdec249",
+    "zh:b59abd0a980649c2f97f172392f080eaeb18e486b603f83bf95f5d93aeccc090",
+    "zh:ba6e3060fddf4a022087d8f09e38aa0001c705f21170c2ded3d1c26c12f70d97",
+    "zh:c12626d044b1d5501cf95ca78cbe507c13ad1dd9f12d4736df66eb8e5f336eb8",
+    "zh:c55203240d50f4cdeb3df1e1760630d677679f5b1a6ffd9eba23662a4ad05119",
+    "zh:ea206a5a32d6e0d6e32f1849ad703da9a28355d9c516282a8458b5cf1502b2a1",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/modules/namespaces/tests/team-namespaces.tftest.hcl
+++ b/modules/namespaces/tests/team-namespaces.tftest.hcl
@@ -3,7 +3,7 @@ mock_provider "kubernetes" {
 }
 
 variables {
-  project_name = "eks-security-infra"
+  project_name = "eks-secure-infra"
   team_names   = ["team-a", "team-b", "team-c", "team-d"]
 }
 

--- a/modules/vpc/.terraform.lock.hcl
+++ b/modules/vpc/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/vpc/tests/network-layout.tftest.hcl
+++ b/modules/vpc/tests/network-layout.tftest.hcl
@@ -3,7 +3,7 @@ mock_provider "aws" {
 }
 
 variables {
-  project_name          = "eks-security-infra"
+  project_name          = "eks-secure-infra"
   environment           = "dev"
   aws_region            = "ap-northeast-2"
   owner                 = "K8RVIS"
@@ -13,7 +13,7 @@ variables {
   private_subnet_cidrs  = ["10.0.10.0/24", "10.0.20.0/24"]
   fck_nat_instance_type = "t4g.nano"
   default_tags = {
-    Repository = "eks-security-infra"
+    Repository = "eks-secure-infra"
     ManagedBy  = "terraform"
   }
 }


### PR DESCRIPTION
## 무엇을 만들었나요? (What)
- terraform에 작성된 eks-security-infra -> eks-secure-infra로 변경
- .terraform.lock.hcl 파일 추가

## 왜 이렇게 만들었나요? (Why)
- 취약한 환경 eks-vulnerable-infra에 맞게 안전한 환경 eks-secure-infra로 변경함 (명사 -> 형용사)
- 봇을 사용하게 되면 매번 terraform init을 하며 provider를 다시 다운로드하는데, .terraform.lock.hcl이 없으면 해당 시점의 가장 최신 파일을 다운로드받아 충돌이 발생할 수 있음
- 따라서 환경 일관성을 위해 .terraform.lock.hcl 파일을 추가함