### PR TITLE
[Feat] Default SA 제한 및 토큰 비활성화 (team-d)

### DIFF
--- a/manifests/overlays/team-d/api-deployment-patch.yaml
+++ b/manifests/overlays/team-d/api-deployment-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      serviceAccountName: api-workload
+      automountServiceAccountToken: false

--- a/manifests/overlays/team-d/api-serviceaccount.yaml
+++ b/manifests/overlays/team-d/api-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api-workload
+automountServiceAccountToken: false

--- a/manifests/overlays/team-d/default-serviceaccount.yaml
+++ b/manifests/overlays/team-d/default-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false

--- a/manifests/overlays/team-d/kustomization.yaml
+++ b/manifests/overlays/team-d/kustomization.yaml
@@ -5,9 +5,15 @@ namespace: team-d
 
 resources:
   - ../../base
+  - default-serviceaccount.yaml
+  - api-serviceaccount.yaml
 
 patches:
   - path: web-ingress-patch.yaml
     target:
       kind: Ingress
       name: web
+  - path: api-deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: api


### PR DESCRIPTION
## 관련 이슈
- Closes #1 

## 무엇을 만들었나요? (What)
- `default` ServiceAccount의 자동 토큰 마운트를 비활성화한다.
- `api` 워크로드가 `default` ServiceAccount를 직접 사용하지 않도록 한다.
- `api` 워크로드에 전용 ServiceAccount를 부여하고 토큰 자동 마운트를 비활성화한다.

## 왜 이렇게 만들었나요? (Why)
기존 insecure baseline에서는 `api` 워크로드가 `default` ServiceAccount를 사용하고 있고, `automountServiceAccountToken: true` 상태였습니다. 이 상태는 Kubernetes API를 직접 사용하지 않는 워크로드에도 토큰이 Pod 내부에 자동 마운트될 수 있어 취약점이 발생합니다.

따라서 다음과 같은 수정을 진행했습니다.
- team-d overlay에 `default` ServiceAccount 리소스 추가 및 `automountServiceAccountToken: false` 설정
- api-workload 전용 ServiceAccount 추가 및 `automountServiceAccountToken: false` 설정
- api Deployment에 `serviceAccountName: api-workload` 적용 및 `automountServiceAccountToken: false` 적용
- `kustomization.yaml`에 위 리소스와 patch 포함

## 실습 진행
<img width="765" height="306" alt="image33" src="https://github.com/user-attachments/assets/01e9d0ab-4aa0-4bf7-b8c3-9a9d4911f61e" />
DB가 떠있지 않지만 일단 이번에는 web과 api만 사용하므로 스킵함

<br></br>

<img width="1260" height="100" alt="image34" src="https://github.com/user-attachments/assets/a3a40b23-dd44-4625-986d-bf1fe833ea1b" />
namespace에서 사용하고 있는 ServiceAccount를 확인해보니 default였음
api(백엔드) 워크로드에서도 default ServiceAccount를 사용하고 있었음

<br></br>

<img width="1479" height="198" alt="image35" src="https://github.com/user-attachments/assets/573b37dd-86cc-4650-b8cf-7790e1d88a98" />
`kubectl apply -k /Users/esc/Desktop/K8RVIS/eks-secure-infra/manifests/overlays/team-d` 명령어로 수정 파일을 적용함

<br></br>

<img width="1194" height="176" alt="image36" src="https://github.com/user-attachments/assets/656d6c05-3fa4-484d-bc42-10bd83999539" />
적용 후 다음과 같은 변경 사항을 확인함

- default ServiceAccount의 automountServiceAccountToken 값이 false
- api-workload ServiceAccount의 automountServiceAccountToken 값이 false
- api Deployment의 serviceAccountName 값이 api-workload
- api Deployment의 automountServiceAccountToken 값이 false

<br></br>

## 참고
- 각자 실습한 내용과 무엇이 다른지, 추가적으로 적용할 수 있는 다른 것이 있는지 비교하며 작성하면 좋겠습니다.
