### PR TITLE
[feat] default SA 비활성화 설정(team-b)

### DIFF
--- a/manifests/overlays/team-b/kustomization.yaml
+++ b/manifests/overlays/team-b/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: team-b
 
 resources:
   - ../../base
-
+  - sa-patch.yaml  
 patches:
   - path: web-ingress-patch.yaml
     target:

--- a/manifests/overlays/team-b/sa-patch.yaml
+++ b/manifests/overlays/team-b/sa-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: team-b
+automountServiceAccountToken: false


### PR DESCRIPTION
## 관련 이슈
- Closes  #1 

## 무엇을 만들었나요? (What)
- default ServiceAccount에 `automountServiceAccountToken: false` 설정을 Kustomize patch 방식으로 적용
- `sa-patch.yaml` 파일을 생성하여 SA를 직접 선언하고, `kustomization.yaml`의 `resources` 섹션에 등록

## 왜 이렇게 만들었나요? (Why)
- 처음에는 SA 직접 패치 방식으로 설정하면 해당 SA를 사용하는 모든 Pod에 일괄 적용되므로, 이후에 새로운 Deployment가 추가되더라도 별도 설정 없이 보안이 유지될거라고 판단

→ base에 `default` SA 리소스가 별도로 정의되어 있지 않아 patch 대상이 無

- Kubernetes는 namespace 생성 시 `default` SA를 자동 생성하지만 이는 Kustomize가 인식하는 리소스가 아니기 때문에, `sa-patch.yaml`을 `resources`로 등록하여 SA를 직접 선언하는 방식으로 적용

## 테스트
- `kubectal get nodes`

<img width="676" height="70" alt="화면 캡처 2026-04-20 224523" src="https://github.com/user-attachments/assets/873a67e2-ecd1-4390-9b87-4417ef9507df" />

- `sa-patch.yaml` 생성

<img width="942" height="117" alt="스크린샷 2026-04-20 214843" src="https://github.com/user-attachments/assets/01301765-e596-45c3-94d4-e51bc43eb9b3" />

- `kustomization.yaml` 수정

 `vi manifests/overlays/team-b/kustomization.yaml`

- 실제 클러스터 적용

`kubectl apply -k manifests/overlays/team-b`

- Acceptance Criteria 검증

<img width="1107" height="219" alt="스크린샷 2026-04-20 221939" src="https://github.com/user-attachments/assets/5d92f81c-b0df-44ff-8d5d-91869f8aa1f3" />


- Pod 띄워서 검증

<img width="964" height="116" alt="스크린샷 2026-04-20 222750" src="https://github.com/user-attachments/assets/4c5f3593-3527-4260-b5be-4fc25d20f3d2" />


## 참고
참고해서 읽어본 자료

-  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

- https://kyverno.io/policies/other/disable-automountserviceaccounttoken/disable-automountserviceaccounttoken/