### PR TITLE
[Feat] default SA 비활성화 설정 (team-a)

### DIFF
--- a/manifests/overlays/team-a/default-sa-token-patch.yaml
+++ b/manifests/overlays/team-a/default-sa-token-patch.yaml
@@ -1,0 +1,26 @@
+﻿apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      automountServiceAccountToken: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    spec:
+      automountServiceAccountToken: false
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+spec:
+  template:
+    spec:
+      automountServiceAccountToken: false

--- a/manifests/overlays/team-a/default-serviceaccount.yaml
+++ b/manifests/overlays/team-a/default-serviceaccount.yaml
@@ -1,0 +1,5 @@
+﻿apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false

--- a/manifests/overlays/team-a/kustomization.yaml
+++ b/manifests/overlays/team-a/kustomization.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
+﻿apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 namespace: team-a
@@ -6,8 +6,10 @@ namespace: team-a
 resources:
   - ../../base
 
+  - default-serviceaccount.yaml
 patches:
   - path: web-ingress-patch.yaml
     target:
       kind: Ingress
       name: web
+  - path: default-sa-token-patch.yaml

--- a/scripts/generate-default-sa-token-patch.ps1
+++ b/scripts/generate-default-sa-token-patch.ps1
@@ -1,0 +1,306 @@
+param(
+  [string]$Overlay = "manifests/overlays/team-a",
+  [string]$ServiceAccountFileName = "default-serviceaccount.yaml",
+  [string]$PatchFileName = "default-sa-token-patch.yaml"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-ServiceAccountName {
+  param($Doc)
+
+  if ($Doc.kind -eq "CronJob") {
+    return $Doc.spec.jobTemplate.spec.template.spec.serviceAccountName
+  }
+
+  if ($Doc.kind -eq "Pod") {
+    return $Doc.spec.serviceAccountName
+  }
+
+  return $Doc.spec.template.spec.serviceAccountName
+}
+
+function Get-AutomountValue {
+  param($Doc)
+
+  if ($Doc.kind -eq "CronJob") {
+    return $Doc.spec.jobTemplate.spec.template.spec.automountServiceAccountToken
+  }
+
+  if ($Doc.kind -eq "Pod") {
+    return $Doc.spec.automountServiceAccountToken
+  }
+
+  if ($Doc.kind -eq "ServiceAccount") {
+    return $Doc.automountServiceAccountToken
+  }
+
+  return $Doc.spec.template.spec.automountServiceAccountToken
+}
+
+function Uses-DefaultServiceAccount {
+  param($Doc)
+
+  $sa = Get-ServiceAccountName $Doc
+  return [string]::IsNullOrEmpty($sa) -or $sa -eq "default"
+}
+
+function Build-PatchDocument {
+  param($Doc)
+
+  if ($Doc.kind -eq "CronJob") {
+    return [ordered]@{
+      apiVersion = $Doc.apiVersion
+      kind       = $Doc.kind
+      metadata   = [ordered]@{ name = $Doc.metadata.name }
+      spec       = [ordered]@{
+        jobTemplate = [ordered]@{
+          spec = [ordered]@{
+            template = [ordered]@{
+              spec = [ordered]@{
+                automountServiceAccountToken = $false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if ($Doc.kind -eq "Pod") {
+    return [ordered]@{
+      apiVersion = $Doc.apiVersion
+      kind       = $Doc.kind
+      metadata   = [ordered]@{ name = $Doc.metadata.name }
+      spec       = [ordered]@{
+        automountServiceAccountToken = $false
+      }
+    }
+  }
+
+  return [ordered]@{
+    apiVersion = $Doc.apiVersion
+    kind       = $Doc.kind
+    metadata   = [ordered]@{ name = $Doc.metadata.name }
+    spec       = [ordered]@{
+      template = [ordered]@{
+        spec = [ordered]@{
+          automountServiceAccountToken = $false
+        }
+      }
+    }
+  }
+}
+
+function ConvertTo-YamlSimple {
+  param(
+    [object]$Value,
+    [int]$Indent = 0
+  )
+
+  $spaces = " " * $Indent
+  $lines = New-Object System.Collections.Generic.List[string]
+
+  foreach ($key in $Value.Keys) {
+    $item = $Value[$key]
+
+    if ($item -is [System.Collections.IDictionary]) {
+      $lines.Add("${spaces}${key}:")
+      foreach ($line in (ConvertTo-YamlSimple -Value $item -Indent ($Indent + 2))) {
+        $lines.Add($line)
+      }
+    } else {
+      $rendered = if ($item -is [bool]) { $item.ToString().ToLower() } else { "$item" }
+      $lines.Add("${spaces}${key}: $rendered")
+    }
+  }
+
+  return $lines
+}
+
+function Add-KustomizationEntry {
+  param(
+    [string]$Path,
+    [string]$Section,
+    [string]$Entry
+  )
+
+  $lines = @(Get-Content $Path)
+
+  if ($lines -contains "  - $Entry") {
+    return
+  }
+
+  $sectionIndex = -1
+
+  for ($i = 0; $i -lt $lines.Count; $i++) {
+    if ($lines[$i] -match "^$Section\s*:\s*$") {
+      $sectionIndex = $i
+      break
+    }
+  }
+
+  if ($sectionIndex -eq -1) {
+    $lines += ""
+    $lines += "${Section}:"
+    $lines += "  - $Entry"
+    Set-Content -Path $Path -Value $lines -Encoding UTF8
+    return
+  }
+
+  $insertIndex = $lines.Count
+
+  for ($i = $sectionIndex + 1; $i -lt $lines.Count; $i++) {
+    if ($lines[$i] -match "^[A-Za-z0-9_-]+\s*:") {
+      $insertIndex = $i
+      break
+    }
+  }
+
+  $updated = @()
+
+  if ($insertIndex -gt 0) {
+    $updated += $lines[0..($insertIndex - 1)]
+  }
+
+  $updated += "  - $Entry"
+
+  if ($insertIndex -lt $lines.Count) {
+    $updated += $lines[$insertIndex..($lines.Count - 1)]
+  }
+
+  Set-Content -Path $Path -Value $updated -Encoding UTF8
+}
+
+$overlayPath = Resolve-Path $Overlay
+$kustomizationPath = Join-Path $overlayPath "kustomization.yaml"
+$serviceAccountPath = Join-Path $overlayPath $ServiceAccountFileName
+$patchPath = Join-Path $overlayPath $PatchFileName
+
+if (-not (Test-Path $kustomizationPath)) {
+  throw "kustomization.yaml not found: $kustomizationPath"
+}
+
+if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+  throw "kubectl is not installed or not in PATH."
+}
+
+Write-Host "[1] Render overlay"
+$rendered = (kubectl kustomize $overlayPath) -join "`n"
+
+Write-Host "[2] Generate default ServiceAccount resource"
+$serviceAccountDoc = [ordered]@{
+  apiVersion = "v1"
+  kind       = "ServiceAccount"
+  metadata   = [ordered]@{ name = "default" }
+  automountServiceAccountToken = $false
+}
+
+Set-Content -Path $serviceAccountPath -Value (ConvertTo-YamlSimple -Value $serviceAccountDoc) -Encoding UTF8
+
+Write-Host "[3] Parse rendered resources and build workload patches"
+$docs = $rendered -split "(?m)^---\s*$"
+$patchDocs = New-Object System.Collections.Generic.List[object]
+$supportedKinds = @("Pod", "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "ReplicaSet", "ReplicationController")
+
+foreach ($chunk in $docs) {
+  $text = $chunk.Trim()
+
+  if ([string]::IsNullOrWhiteSpace($text)) {
+    continue
+  }
+
+  $json = $text | kubectl create --dry-run=client --validate=false -f - -o json 2>$null
+
+
+  if (-not $json) {
+    continue
+  }
+
+  $doc = $json | ConvertFrom-Json
+
+  if ($supportedKinds -notcontains $doc.kind) {
+    continue
+  }
+
+  if (-not (Uses-DefaultServiceAccount $doc)) {
+    Write-Host "Skipping $($doc.kind)/$($doc.metadata.name): non-default ServiceAccount"
+    continue
+  }
+
+  Write-Host "Adding patch for $($doc.kind)/$($doc.metadata.name)"
+  $patchDocs.Add((Build-PatchDocument $doc))
+}
+
+Write-Host "[4] Write workload patch file"
+$yamlLines = New-Object System.Collections.Generic.List[string]
+
+for ($i = 0; $i -lt $patchDocs.Count; $i++) {
+  if ($i -gt 0) {
+    $yamlLines.Add("---")
+  }
+
+  foreach ($line in (ConvertTo-YamlSimple -Value $patchDocs[$i])) {
+    $yamlLines.Add($line)
+  }
+}
+
+Set-Content -Path $patchPath -Value $yamlLines -Encoding UTF8
+
+Write-Host "[5] Register generated files in kustomization.yaml"
+Add-KustomizationEntry -Path $kustomizationPath -Section "resources" -Entry $ServiceAccountFileName
+Add-KustomizationEntry -Path $kustomizationPath -Section "patches" -Entry "path: $PatchFileName"
+
+Write-Host "[6] Verify"
+$verifyRendered = (kubectl kustomize $overlayPath) -join "`n"
+$verifyDocs = $verifyRendered -split "(?m)^---\s*$"
+$verifyRows = New-Object System.Collections.Generic.List[object]
+
+foreach ($chunk in $verifyDocs) {
+  $text = $chunk.Trim()
+
+  if ([string]::IsNullOrWhiteSpace($text)) {
+    continue
+  }
+
+  $json = $text | kubectl create --dry-run=client --validate=false -f - -o json 2>$null
+
+  if (-not $json) {
+    continue
+  }
+
+  $doc = $json | ConvertFrom-Json
+
+  if ($doc.kind -eq "ServiceAccount" -and $doc.metadata.name -eq "default") {
+    $automount = Get-AutomountValue $doc
+    $verifyRows.Add([PSCustomObject]@{
+      Kind        = $doc.kind
+      Name        = $doc.metadata.name
+      ServiceAcct = "-"
+      Automount   = if ($null -eq $automount) { "<unset>" } else { $automount }
+      Status      = if ($automount -eq $false) { "OK" } else { "CHECK" }
+    })
+    continue
+  }
+
+  if ($supportedKinds -notcontains $doc.kind) {
+    continue
+  }
+
+  $sa = Get-ServiceAccountName $doc
+
+  if (-not ([string]::IsNullOrEmpty($sa) -or $sa -eq "default")) {
+    continue
+  }
+
+  $automount = Get-AutomountValue $doc
+  $verifyRows.Add([PSCustomObject]@{
+    Kind        = $doc.kind
+    Name        = $doc.metadata.name
+    ServiceAcct = if ([string]::IsNullOrEmpty($sa)) { "<default>" } else { $sa }
+    Automount   = if ($null -eq $automount) { "<unset>" } else { $automount }
+    Status      = if ($automount -eq $false) { "OK" } else { "CHECK" }
+  })
+}
+
+$verifyRows | Sort-Object Kind, Name | Format-Table -AutoSize

--- a/scripts/generate-default-sa-token-patch.sh
+++ b/scripts/generate-default-sa-token-patch.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OVERLAY="${1:-manifests/overlays/team-a}"
+SERVICE_ACCOUNT_FILE_NAME="${2:-default-serviceaccount.yaml}"
+PATCH_FILE_NAME="${3:-default-sa-token-patch.yaml}"
+
+KUSTOMIZATION_PATH="$OVERLAY/kustomization.yaml"
+SERVICE_ACCOUNT_PATH="$OVERLAY/$SERVICE_ACCOUNT_FILE_NAME"
+PATCH_PATH="$OVERLAY/$PATCH_FILE_NAME"
+
+ensure_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "$1 is not installed or not in PATH."
+    exit 1
+  fi
+}
+
+add_kustomization_entry() {
+  local section="$1"
+  local entry="$2"
+  local file="$3"
+  local tmp_file
+
+  if grep -qxF "  - $entry" "$file"; then
+    return
+  fi
+
+  tmp_file="$(mktemp)"
+
+  awk -v section="$section" -v entry="  - $entry" '
+    BEGIN {
+      in_section = 0
+      section_seen = 0
+      added = 0
+    }
+
+    $0 ~ "^" section ":[[:space:]]*$" {
+      print
+      in_section = 1
+      section_seen = 1
+      next
+    }
+
+    in_section && $0 ~ "^[A-Za-z0-9_-]+:[[:space:]]*$" {
+      if (!added) {
+        print entry
+        added = 1
+      }
+      in_section = 0
+    }
+
+    {
+      print
+    }
+
+    END {
+      if (!section_seen) {
+        print ""
+        print section ":"
+        print entry
+      } else if (in_section && !added) {
+        print entry
+      }
+    }
+  ' "$file" > "$tmp_file"
+
+  mv "$tmp_file" "$file"
+}
+
+render_patch_doc() {
+  local kind="$1"
+  local api_version="$2"
+  local name="$3"
+
+  if [[ "$kind" == "CronJob" ]]; then
+    cat <<EOF
+apiVersion: $api_version
+kind: $kind
+metadata:
+  name: $name
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          automountServiceAccountToken: false
+EOF
+  elif [[ "$kind" == "Pod" ]]; then
+    cat <<EOF
+apiVersion: $api_version
+kind: $kind
+metadata:
+  name: $name
+spec:
+  automountServiceAccountToken: false
+EOF
+  else
+    cat <<EOF
+apiVersion: $api_version
+kind: $kind
+metadata:
+  name: $name
+spec:
+  template:
+    spec:
+      automountServiceAccountToken: false
+EOF
+  fi
+}
+
+get_service_account_name() {
+  local kind="$1"
+  local json="$2"
+
+  if [[ "$kind" == "CronJob" ]]; then
+    printf '%s\n' "$json" | jq -r '.spec.jobTemplate.spec.template.spec.serviceAccountName // ""'
+  elif [[ "$kind" == "Pod" ]]; then
+    printf '%s\n' "$json" | jq -r '.spec.serviceAccountName // ""'
+  else
+    printf '%s\n' "$json" | jq -r '.spec.template.spec.serviceAccountName // ""'
+  fi
+}
+
+get_automount_value() {
+  local kind="$1"
+  local json="$2"
+
+  if [[ "$kind" == "CronJob" ]]; then
+    printf '%s\n' "$json" | jq -r '.spec.jobTemplate.spec.template.spec.automountServiceAccountToken // "<unset>"'
+  elif [[ "$kind" == "Pod" ]]; then
+    printf '%s\n' "$json" | jq -r '.spec.automountServiceAccountToken // "<unset>"'
+  elif [[ "$kind" == "ServiceAccount" ]]; then
+    printf '%s\n' "$json" | jq -r '.automountServiceAccountToken // "<unset>"'
+  else
+    printf '%s\n' "$json" | jq -r '.spec.template.spec.automountServiceAccountToken // "<unset>"'
+  fi
+}
+
+ensure_command kubectl
+ensure_command jq
+
+if [[ ! -f "$KUSTOMIZATION_PATH" ]]; then
+  echo "kustomization.yaml not found: $KUSTOMIZATION_PATH"
+  exit 1
+fi
+
+echo "[1] Render overlay"
+RENDERED="$(kubectl kustomize "$OVERLAY")"
+
+echo "[2] Generate default ServiceAccount resource"
+cat > "$SERVICE_ACCOUNT_PATH" <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false
+EOF
+
+echo "[3] Parse rendered resources and build workload patches"
+TMP_PATCH_DOCS="$(mktemp)"
+trap 'rm -f "$TMP_PATCH_DOCS"' EXIT
+: > "$TMP_PATCH_DOCS"
+
+SUPPORTED_KINDS_REGEX='^(Pod|Deployment|StatefulSet|DaemonSet|Job|CronJob|ReplicaSet|ReplicationController)$'
+FIRST_DOC="true"
+
+DOC=""
+while IFS= read -r line; do
+  if [[ "$line" =~ ^---[[:space:]]*$ ]]; then
+    if [[ -n "$DOC" ]]; then
+      JSON="$(printf '%s\n' "$DOC" | kubectl create --dry-run=client --validate=false -f - -o json 2>/dev/null || true)"
+
+      if [[ -n "$JSON" ]]; then
+        KIND="$(printf '%s\n' "$JSON" | jq -r '.kind')"
+        API_VERSION="$(printf '%s\n' "$JSON" | jq -r '.apiVersion')"
+        NAME="$(printf '%s\n' "$JSON" | jq -r '.metadata.name')"
+
+        if [[ "$KIND" =~ $SUPPORTED_KINDS_REGEX ]]; then
+          SA="$(get_service_account_name "$KIND" "$JSON")"
+
+          if [[ -n "$SA" && "$SA" != "default" ]]; then
+            echo "Skipping $KIND/$NAME: non-default ServiceAccount"
+          else
+            echo "Adding patch for $KIND/$NAME"
+
+            if [[ "$FIRST_DOC" == "true" ]]; then
+              FIRST_DOC="false"
+            else
+              printf '%s\n' "---" >> "$TMP_PATCH_DOCS"
+            fi
+
+            render_patch_doc "$KIND" "$API_VERSION" "$NAME" >> "$TMP_PATCH_DOCS"
+          fi
+        fi
+      fi
+
+      DOC=""
+    fi
+
+    continue
+  fi
+
+  DOC="${DOC}${line}"$'\n'
+done <<< "$RENDERED"
+
+if [[ -n "$DOC" ]]; then
+  JSON="$(printf '%s\n' "$DOC" | kubectl create --dry-run=client --validate=false -f - -o json 2>/dev/null || true)"
+
+  if [[ -n "$JSON" ]]; then
+    KIND="$(printf '%s\n' "$JSON" | jq -r '.kind')"
+    API_VERSION="$(printf '%s\n' "$JSON" | jq -r '.apiVersion')"
+    NAME="$(printf '%s\n' "$JSON" | jq -r '.metadata.name')"
+
+    if [[ "$KIND" =~ $SUPPORTED_KINDS_REGEX ]]; then
+      SA="$(get_service_account_name "$KIND" "$JSON")"
+
+      if [[ -n "$SA" && "$SA" != "default" ]]; then
+        echo "Skipping $KIND/$NAME: non-default ServiceAccount"
+      else
+        echo "Adding patch for $KIND/$NAME"
+
+        if [[ "$FIRST_DOC" == "true" ]]; then
+          FIRST_DOC="false"
+        else
+          printf '%s\n' "---" >> "$TMP_PATCH_DOCS"
+        fi
+
+        render_patch_doc "$KIND" "$API_VERSION" "$NAME" >> "$TMP_PATCH_DOCS"
+      fi
+    fi
+  fi
+fi
+
+echo "[4] Write workload patch file"
+cp "$TMP_PATCH_DOCS" "$PATCH_PATH"
+
+echo "[5] Register generated files in kustomization.yaml"
+add_kustomization_entry "resources" "$SERVICE_ACCOUNT_FILE_NAME" "$KUSTOMIZATION_PATH"
+add_kustomization_entry "patches" "path: $PATCH_FILE_NAME" "$KUSTOMIZATION_PATH"
+
+echo "[6] Verify"
+VERIFY_RENDERED="$(kubectl kustomize "$OVERLAY")"
+VERIFY_ROWS="$(mktemp)"
+trap 'rm -f "$TMP_PATCH_DOCS" "$VERIFY_ROWS"' EXIT
+: > "$VERIFY_ROWS"
+
+DOC=""
+while IFS= read -r line; do
+  if [[ "$line" =~ ^---[[:space:]]*$ ]]; then
+    if [[ -n "$DOC" ]]; then
+      JSON="$(printf '%s\n' "$DOC" | kubectl create --dry-run=client --validate=false -f - -o json 2>/dev/null || true)"
+      DOC=""
+
+      if [[ -n "$JSON" ]]; then
+        KIND="$(printf '%s\n' "$JSON" | jq -r '.kind')"
+        NAME="$(printf '%s\n' "$JSON" | jq -r '.metadata.name')"
+
+        if [[ "$KIND" == "ServiceAccount" && "$NAME" == "default" ]]; then
+          AUTOMOUNT="$(get_automount_value "$KIND" "$JSON")"
+          STATUS="CHECK"
+          [[ "$AUTOMOUNT" == "false" ]] && STATUS="OK"
+          printf '%s\t%s\t%s\t%s\t%s\n' "$KIND" "$NAME" "-" "$AUTOMOUNT" "$STATUS" >> "$VERIFY_ROWS"
+        elif [[ "$KIND" =~ $SUPPORTED_KINDS_REGEX ]]; then
+          SA="$(get_service_account_name "$KIND" "$JSON")"
+
+          if [[ -z "$SA" || "$SA" == "default" ]]; then
+            AUTOMOUNT="$(get_automount_value "$KIND" "$JSON")"
+            STATUS="CHECK"
+            [[ "$AUTOMOUNT" == "false" ]] && STATUS="OK"
+
+            if [[ -z "$SA" ]]; then
+              SA="<default>"
+            fi
+
+            printf '%s\t%s\t%s\t%s\t%s\n' "$KIND" "$NAME" "$SA" "$AUTOMOUNT" "$STATUS" >> "$VERIFY_ROWS"
+          fi
+        fi
+      fi
+    fi
+
+    continue
+  fi
+
+  DOC="${DOC}${line}"$'\n'
+done <<< "$VERIFY_RENDERED"
+
+if [[ -n "$DOC" ]]; then
+  JSON="$(printf '%s\n' "$DOC" | kubectl create --dry-run=client --validate=false -f - -o json 2>/dev/null || true)"
+
+  if [[ -n "$JSON" ]]; then
+    KIND="$(printf '%s\n' "$JSON" | jq -r '.kind')"
+    NAME="$(printf '%s\n' "$JSON" | jq -r '.metadata.name')"
+
+    if [[ "$KIND" == "ServiceAccount" && "$NAME" == "default" ]]; then
+      AUTOMOUNT="$(get_automount_value "$KIND" "$JSON")"
+      STATUS="CHECK"
+      [[ "$AUTOMOUNT" == "false" ]] && STATUS="OK"
+      printf '%s\t%s\t%s\t%s\t%s\n' "$KIND" "$NAME" "-" "$AUTOMOUNT" "$STATUS" >> "$VERIFY_ROWS"
+    elif [[ "$KIND" =~ $SUPPORTED_KINDS_REGEX ]]; then
+      SA="$(get_service_account_name "$KIND" "$JSON")"
+
+      if [[ -z "$SA" || "$SA" == "default" ]]; then
+        AUTOMOUNT="$(get_automount_value "$KIND" "$JSON")"
+        STATUS="CHECK"
+        [[ "$AUTOMOUNT" == "false" ]] && STATUS="OK"
+
+        if [[ -z "$SA" ]]; then
+          SA="<default>"
+        fi
+
+        printf '%s\t%s\t%s\t%s\t%s\n' "$KIND" "$NAME" "$SA" "$AUTOMOUNT" "$STATUS" >> "$VERIFY_ROWS"
+      fi
+    fi
+  fi
+fi
+
+{
+  printf 'Kind\tName\tServiceAcct\tAutomount\tStatus\n'
+  sort -k1,1 -k2,2 "$VERIFY_ROWS"
+} | column -t -s $'\t'


### PR DESCRIPTION
## 관련 이슈
- Closes https://github.com/K8RVIS/eks-secure-infra/issues/1

## 무엇을 만들었나요? (What)
- patch 생성을 자동화 하는 스크립트를 추가하였다. 
> Windows PowerShell: scripts/generate-default-sa-token-patch.ps1
> Linux Bash: scripts/generate-default-sa-token-patch.sh

- `kustomization.yaml` 의 resources와 paches 섹션에 항목을 추가하고, 실제 overlay 렌더링 결과를 기준으로 패치할 리소르를 선정한다. 이때, 리소스 종류별로 SA를 확인하여 default SA가 적용된 리소스를 패치 대상으로 선정한다. 
- `default-serviceaccount.yaml` 를 통해 default SA 자체를 리소스로 선언하고, `default-sa-token-patch.yaml`를 통해 default SA를 쓰는 워크로드만 패치하도록 yaml파일을 생성한다.

## 왜 이렇게 만들었나요? (Why)
- Kubernetes는 ServiceAccount를 명시하지 않은 Pod에 기본적으로 default ServiceAccount를 할당할 수 있고, 토큰이 자동 마운트될 수 있으며, API 호출이 필요 없는 일반 앱에 토큰이 마운트되면, Pod 침해 시 Kubernetes API 접근 토큰이 노출될 위험이 있다. 
- 따라서 별도 ServiceAccount를 사용하는 워크로드는 의도적으로 권한이 필요한 경우일 수 있으므로 제외하고, default ServiceAccount를 사용하는 리소스만 대상으로 패치를 진행하고자 하였다. 
- Windows과 Linux 환경 모두에서 동일하게 패치 파일을 생성할 수 있도록 스크립트를 분리하여 작성하였다. 

## 테스트
<img width="533" height="356" alt="image" src="https://github.com/user-attachments/assets/a751fce9-bbfd-4348-9bce-92fc83a6ad88" />

<img width="224" height="53" alt="image" src="https://github.com/user-attachments/assets/30333771-0ecf-4eeb-8496-3d1d2e945fc9" />

`team-a` namespace에서 사용하는 ServiceAccount가 default임을 확인하였다. 
스크립트를 통해 다음과 같이 적용되는 것을 알 수 있다.

<img width="419" height="298" alt="image" src="https://github.com/user-attachments/assets/208d85ca-d2f3-49e0-ba2f-5e475145996e" />

이후 생성된 결과를 확인하기 위해 kubectl kustomize manifests/overlays/team-a >.\team-a-patch.yaml 를 통해 생성된 파일을 비교해보면, 아래와 같이 생성 및 수정된 내용을 확인할 수 있다.  

<img width="604" height="138" alt="스크린샷 2026-04-27 024234" src="https://github.com/user-attachments/assets/1c152367-6f52-4807-bc90-c64837130ebc" />


<img width="602" height="402" alt="스크린샷 2026-04-27 024256" src="https://github.com/user-attachments/assets/c077d14d-b475-4998-a53d-88628861ddef" />


<img width="595" height="379" alt="스크린샷 2026-04-27 024313" src="https://github.com/user-attachments/assets/1bb68624-26ed-454b-a361-3447dbe04022" />


<img width="596" height="401" alt="스크린샷 2026-04-27 024325" src="https://github.com/user-attachments/assets/65e26024-4c71-4657-b086-c0d73f968b32" />

변경된 내용을 확인한 후, kubectl apply -k manifests/overlays/team-a 를 통해 해당 내용을 적용한다. 

<img width="1067" height="203" alt="스크린샷 2026-04-27 024517" src="https://github.com/user-attachments/assets/133b8a77-46d8-4a49-b19c-2a4509989a0a" />

아래와 같이 수정한 내용이 반영된 것을 확인할 수 있다. 
<img width="1066" height="291" alt="image" src="https://github.com/user-attachments/assets/33e0665d-151b-49b2-847e-d68e1067f1a7" />


## 참고
https://kubernetes.io/ko/docs/concepts/security/service-accounts/