### PR TITLE
[feat] Container root 권한 제한 설정(team-b)

### DIFF
--- a/manifests/base/api/deployment.yaml
+++ b/manifests/base/api/deployment.yaml
@@ -37,3 +37,8 @@ spec:
           ports:
             - containerPort: 80
               name: http
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false

--- a/manifests/base/db/statefulset.yaml
+++ b/manifests/base/db/statefulset.yaml
@@ -17,6 +17,8 @@ spec:
         app.kubernetes.io/name: db
         training.k8rvis.io/security-baseline: insecure
     spec:
+      securityContext:
+        fsGroup: 999
       containers:
         - name: db
           image: redis:7
@@ -31,9 +33,19 @@ spec:
           ports:
             - containerPort: 6379
               name: redis
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           volumeMounts:
             - name: redis-data
               mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: redis-data

--- a/manifests/base/web/deployment.yaml
+++ b/manifests/base/web/deployment.yaml
@@ -18,10 +18,26 @@ spec:
     spec:
       containers:
         - name: web
-          image: nginx:1.27.5
+          image: nginxinc/nginx-unprivileged:1.27
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               name: http
           securityContext:
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsNonRoot: true
+            runAsUser: 101
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: cache
+              mountPath: /var/cache/nginx
+            - name: run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/manifests/overlays/team-b/kustomization.yaml
+++ b/manifests/overlays/team-b/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: team-b
 
 resources:
   - ../../base
-
+  - sa-patch.yaml  
 patches:
   - path: web-ingress-patch.yaml
     target:

--- a/manifests/overlays/team-b/sa-patch.yaml
+++ b/manifests/overlays/team-b/sa-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: team-b
+automountServiceAccountToken: false


### PR DESCRIPTION
## 관련 이슈
- Closes #

## 무엇을 만들었나요? (What)
- 이번 PR에서 추가하거나 변경한 내용을 적어주세요.
컨테이너가 root 권한 없이 실행되도록 securityContext를 3개 워크로드(api, db, web)에 추가했다. 또한 Terraform으로 네임스페이스에 PSS restricted 정책을 적용해 미준수 Pod는 실행 자체가 거부되도록 했다.

## 왜 이렇게 만들었나요? (Why)
- 이 변경이 필요한 이유와 설계 의도를 적어주세요.
컨테이너는 격리되어 있지만 완전히 안전한 VM이 아니기 때문에, 컨테이너 내부 프로세스가 root로 실행되면 공격자가 침투 시 런타임 조작/악성 도구 설치 등을 훨씬 쉽게 수행할 수 있다. 이를 막기 위해 non-root 실행 강제, 파일시스템 읽기 전용, 권한 상승 차단 설정을 적용했다.

## 테스트
### Step 1. 현재 Pod 상태 확인

`kubectl get pods -n [namespace]`

<img width="474" height="82" alt="image (2)" src="https://github.com/user-attachments/assets/d0647738-1170-4e7f-b7db-40f7b66eacc8" />


Running 중인 Pod 목록 확인

---

### Step 2. 현재 UID 확인 (보안 취약 상태)

`kubectl exec -n [namespace] deploy/api -- id
kubectl exec -n [namespace] deploy/web -- id
kubectl exec -n [namespace] statefulset/db -- id`

`uid=0(root)` 가 나오면 root로 실행 중 → 보안 취약

---

### Step 3. YAML 파일 수정 후 배포

`kubectl apply -k manifests/overlays/[team명]/`

`api`, `db`, `web` 에 `securityContext` 적용 및 `web` 은 `nginxinc/nginx-unprivileged` 이미지로 교체

---

### Step 4. UID 재확인 (보안 적용 후)

`kubectl exec -n [namespace] deploy/api -- id
kubectl exec -n [namespace] deploy/web -- id`

`uid=0` 이 아닌 것을 확인

---

### Step 5. readOnlyRootFilesystem 동작 확인

`kubectl exec -n [namespace] deploy/api -- touch /test
kubectl exec -n [namespace] deploy/web -- touch /test`

`Read-only file system` 에러 출력 → 파일시스템 쓰기 차단 확인

---

### Step 6. Pod Running 상태 최종 확인

`kubectl get pods -n [namespace]`

모든 Pod `STATUS` 가 `Running` 인지 확인

<img width="479" height="87" alt="image (1)" src="https://github.com/user-attachments/assets/7aa5bcde-af32-49fc-b981-dd5cee0caf49" />



추가적으로 StatefulSet에 securityContext를 추가하면서 Pod 스펙이 바뀌었는데, 새 Pod가 뜰 때 PVC를 바인딩할 PV가 없다고 함 그래서 DB가 계속 Pending 됨

---

### 수정 내용
<img width="633" height="391" alt="스크린샷 2026-04-27 115317" src="https://github.com/user-attachments/assets/ab6d5690-1c35-4f4d-9386-fca74bb38a75" />

<img width="662" height="189" alt="image" src="https://github.com/user-attachments/assets/2c01c4dd-a522-421f-a2d3-4852d78b5828" />


→ 테스트 성공!

