### PR TITLE
[feat] Ingress와 Load Balancer에 TLS 강제(team-b)

### DIFF
--- a/environments/platform/.terraform.lock.hcl
+++ b/environments/platform/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
-    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
   constraints = "~> 2.0"
   hashes = [
-    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
     "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
@@ -48,7 +48,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.0"
   hashes = [
-    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
     "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",

--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -23,6 +23,7 @@ module "k8s_base" {
   aws_node_termination_handler_chart_version = var.aws_node_termination_handler_chart_version
   ingress_nginx_namespace                    = var.ingress_nginx_namespace
   ingress_nginx_chart_version                = var.ingress_nginx_chart_version
+  acm_certificate_arn                        = var.acm_certificate_arn
 }
 
 module "namespaces" {

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -78,8 +78,14 @@ variable "ingress_nginx_chart_version" {
 }
 
 variable "acm_certificate_arn" {
-  description = "ARN of the ACM certificate to attach to the ingress-nginx NLB for HTTPS termination."
+  description = "ACM certificate ARN attached to the NLB HTTPS listener."
   type        = string
+}
+
+variable "ssl_policy" {
+  description = "TLS security policy applied to the NLB HTTPS listener."
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 }
 
 variable "argocd_namespace" {

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -77,6 +77,11 @@ variable "ingress_nginx_chart_version" {
   default     = "4.14.1"
 }
 
+variable "acm_certificate_arn" {
+  description = "ARN of the ACM certificate to attach to the ingress-nginx NLB for HTTPS termination."
+  type        = string
+}
+
 variable "argocd_namespace" {
   description = "Namespace used for the ArgoCD installation."
   type        = string

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -82,12 +82,6 @@ variable "acm_certificate_arn" {
   type        = string
 }
 
-variable "ssl_policy" {
-  description = "TLS security policy applied to the NLB HTTPS listener."
-  type        = string
-  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-}
-
 variable "argocd_namespace" {
   description = "Namespace used for the ArgoCD installation."
   type        = string

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -54,14 +54,24 @@ resource "helm_release" "ingress_nginx" {
   wait             = true
 
   values = [
-    <<-EOT
-    controller:
-      ingressClassResource:
-        default: true
-      service:
-        type: LoadBalancer
-        annotations:
-          service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-    EOT
+    yamlencode({
+      controller = {
+        ingressClassResource = { default = true }
+        config = {
+          use-forwarded-headers      = "true"
+          compute-full-forwarded-for = "true"
+        }
+        service = {
+          type = "LoadBalancer"
+          annotations = {
+            "service.beta.kubernetes.io/aws-load-balancer-scheme"                  = "internet-facing"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-cert"                = var.acm_certificate_arn
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-ports"               = "443"
+            "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"        = "tcp"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy"  = var.ssl_policy
+          }
+        }
+      }
+    })
   ]
 }

--- a/modules/k8s-base/variables.tf
+++ b/modules/k8s-base/variables.tf
@@ -45,3 +45,14 @@ variable "ingress_nginx_chart_version" {
   type        = string
   default     = "4.14.1"
 }
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN attached to the NLB HTTPS listener."
+  type        = string
+}
+
+variable "ssl_policy" {
+  description = "TLS security policy applied to the NLB HTTPS listener."
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #9 

## 무엇을 만들었나요? (What)
ingress-nginx Helm 차트에 ACM 인증서 ARN과 TLS 설정을 추가했다 
NLB에 HTTPS가 적용되고 HTTP 접속 시 자동으로 HTTPS로 리다이렉트된다.

## 왜 이렇게 만들었나요? (Why)
평문 HTTP 통신은 세션 탈취 및 데이터 노출 위험이 크다. ACM 인증서를 NLB에 연결해 외부 트래픽을 TLS로 암호화하고, force-ssl-redirect로 HTTP 접속을 HTTPS로 강제 전환하여 평문 통신을 원천 차단한다. YAML 파일을 직접 수정하지 않고 Helm 값으로 설정하면 클러스터 전체에 일괄 적용되어 설정 누락을 방지할 수 있다.

## 테스트
### Step 1. 현재 HTTP 평문 통신 취약점 확인

- NLB 주소 확인

`kubectl get svc -n ingress-nginx`

- HTTP로 접속 시 암호화 없이 통신되는지 확인

`curl -v http://[NLB 주소]`

TLS 없이 평문으로 응답이 오면 → 취약점
<img width="714" height="160" alt="image (13)" src="https://github.com/user-attachments/assets/d2faf3e5-f0a2-4c35-8aaf-e8a07f866f76" />
<img width="727" height="585" alt="image (12)" src="https://github.com/user-attachments/assets/81b143bc-7b44-42b1-8138-19e9eeb34b82" />


---

### Step 2. Terraform 코드 수정 후 적용

`cd environments/platform`

`terraform init
terraform plan 
terraform apply`

<img width="707" height="363" alt="image (11)" src="https://github.com/user-attachments/assets/9252e1f7-325d-4568-9b50-031457f6de41" />


---

### Step 3. HTTPS 리다이렉트 확인

- HTTP 접속 시 HTTPS로 강제 전환되는지 확인

`curl -I http://[NLB 주소]`

`308 Permanent Redirect` + `Location: https://...` 확인

<img width="713" height="179" alt="image (10)" src="https://github.com/user-attachments/assets/f9cd2c2c-d853-4bd7-8dcb-3a92fdebb25e" />



---

### Step 4. TLS 인증서 및 버전 확인

인증서 정보 및 TLS 버전 확인

`curl -v https://[NLB 주소] 2>&1 | grep -E "SSL|TLS|issuer|subject|expire"`

ACM 인증서 정보, TLS 1.2/1.3 확인

<img width="718" height="346" alt="image (9)" src="https://github.com/user-attachments/assets/2a0b6272-e90b-4194-8057-6e1c14a26263" />



---

### Step 5. 구버전 TLS 차단 확인

TLS 1.1 이하 차단 확인 (실패해야 정상)

`curl --tls-max 1.1 https://[NLB 주소]`

`SSL connect error` 출력되면 → 구버전 TLS 차단 확인

<img width="718" height="132" alt="image (8)" src="https://github.com/user-attachments/assets/abad6112-cb28-4745-aa1c-64230b65f0ee" />


## 참고
ACM 도메인 발은 아래 링크를 참고해서 간단하게 실습했다
- https://billtech.tistory.com/24

