### PR TITLE
[Feat] container root 권한 제한 설정 (team-d)

### DIFF
--- a/manifests/overlays/team-d/kustomization.yaml
+++ b/manifests/overlays/team-d/kustomization.yaml
@@ -11,3 +11,7 @@ patches:
     target:
       kind: Ingress
       name: web
+  - path: web-root-restriction-patch.yaml
+    target:
+      kind: Deployment
+      name: web

--- a/manifests/overlays/team-d/web-root-restriction-patch.yaml
+++ b/manifests/overlays/team-d/web-root-restriction-patch.yaml
@@ -1,0 +1,52 @@
+- op: replace
+  path: /metadata/labels/training.k8rvis.io~1security-baseline
+  value: restricted
+- op: replace
+  path: /spec/template/metadata/labels/training.k8rvis.io~1security-baseline
+  value: restricted
+- op: add
+  path: /spec/template/spec/securityContext
+  value:
+    runAsNonRoot: true
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
+    seccompProfile:
+      type: RuntimeDefault
+- op: replace
+  path: /spec/template/spec/containers/0/image
+  value: nginxinc/nginx-unprivileged:1.27
+- op: replace
+  path: /spec/template/spec/containers/0/ports
+  value:
+    - containerPort: 8080
+      name: http
+- op: replace
+  path: /spec/template/spec/containers/0/securityContext
+  value:
+    runAsNonRoot: true
+    runAsUser: 101
+    runAsGroup: 101
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts
+  value:
+    - name: nginx-cache
+      mountPath: /var/cache/nginx
+    - name: nginx-run
+      mountPath: /var/run
+    - name: tmp
+      mountPath: /tmp
+- op: add
+  path: /spec/template/spec/volumes
+  value:
+    - name: nginx-cache
+      emptyDir: {}
+    - name: nginx-run
+      emptyDir: {}
+    - name: tmp
+      emptyDir: {}


### PR DESCRIPTION
## 관련 이슈
- Closes #7

## 무엇을 만들었나요? (What)
- 컨테이너 root 실행 제한 패치 추가
- web Deployment `nginx:1.27.5` root → `nginxinc/nginx-unprivileged:1.27` non-root 실행 구성으로 변경
- `runAsNonRoot: true`, `runAsUser: 101`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]` 적용

## 왜 이렇게 만들었나요? (Why)
- readOnlyRootFilesystem 적용 시 nginx 런타임 쓰기 경로가 필요하므로 전체 root filesystem을 쓰기 가능하게 두지 않고 필요한 경로(/var/cache/nginx, /var/run, /tmp)만 명시적으로 열어둠

## 테스트

### 작업 전

<img width="2000" height="464" alt="image" src="https://github.com/user-attachments/assets/35b6f3ab-ce12-4d93-a511-f0f7981554d8" />

- nginx:1.27.5 → root(uid=0) 로 실행되는 게 기본 세팅
- runAsUser: 0 → root 실행됨
- runAsNonRoot: false → root를 허용하고 있음
- root 경로에 읽고 쓰기 가능 → 컨테이너 탈취 시 root 권한으로 모든 작업이 가능함

### 작업 후

<img width="2010" height="680" alt="image" src="https://github.com/user-attachments/assets/21ac3ff7-532c-4469-816f-a126362a3219" />

- nginxinc/nginx-unprivileged:1.27 = nginx 공식에서 제공하는 비루트 전용 이미지
- "runAsUser": 101 → 기본 유저 uid(101)로 실행됨
- runAsNonRoot: true → root를 제한하고 있음
- root 경로에 읽고 불가능, 다만 nginx 런타임 쓰기에 필요한 경로(/var/cache/nginx, /var/run, /tmp)만 열어둠