### PR TITLE
[feat]  Public API endpoint 접근 CIDR 제한 (team-b)

### DIFF
--- a/environments/infra/.terraform.lock.hcl
+++ b/environments/infra/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 5.0"
   hashes = [
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",

--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -19,10 +19,11 @@ module "eks" {
   project_name       = var.project_name
   environment        = var.environment
   owner              = var.owner
-  cluster_subnet_ids = module.vpc.private_subnet_ids
-  node_subnet_ids    = module.vpc.public_subnet_ids
-  kubernetes_version = var.kubernetes_version
-  node_ami_type      = var.node_ami_type
-  node_group         = var.node_group
-  default_tags       = var.default_tags
+  cluster_subnet_ids  = module.vpc.private_subnet_ids
+  node_subnet_ids     = module.vpc.public_subnet_ids
+  kubernetes_version  = var.kubernetes_version
+  node_ami_type       = var.node_ami_type
+  node_group          = var.node_group
+  public_access_cidrs = var.public_access_cidrs
+  default_tags        = var.default_tags
 }

--- a/environments/infra/variables.tf
+++ b/environments/infra/variables.tf
@@ -62,6 +62,11 @@ variable "node_ami_type" {
   default     = "AL2023_ARM_64_STANDARD"
 }
 
+variable "public_access_cidrs" {
+  description = "CIDR blocks allowed to access the EKS public API endpoint. Must include all admin and CI/CD IPs to avoid lockout."
+  type        = list(string)
+}
+
 variable "node_group" {
   description = "Configuration for the default EKS managed node group."
   type = object({

--- a/environments/platform/backend.tf
+++ b/environments/platform/backend.tf
@@ -1,5 +1,9 @@
 terraform {
   backend "s3" {
-    use_lockfile = true
+    bucket  = "eks-secure-infra-tfstate"
+    key     = "infra/terraform.tfstate"
+    region  = "ap-northeast-2"
+    profile = "team-b"
+    #use_lockfile = true
   }
 }

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -104,6 +104,7 @@ resource "aws_eks_cluster" "this" {
     subnet_ids              = var.cluster_subnet_ids
     endpoint_private_access = true
     endpoint_public_access  = true
+    public_access_cidrs     = var.public_access_cidrs
   }
 
   depends_on = [

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -74,6 +74,16 @@ variable "node_group" {
   }
 }
 
+variable "public_access_cidrs" {
+  description = "CIDR blocks allowed to access the EKS public API endpoint. Must include all admin and CI/CD IPs to avoid lockout."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.public_access_cidrs) > 0
+    error_message = "At least one CIDR block must be specified for public API access."
+  }
+}
+
 variable "default_tags" {
   description = "Additional tags merged into all EKS resources."
   type        = map(string)


### PR DESCRIPTION
## 관련 이슈
- Closes #11 

## 무엇을 만들었나요? (What)
EKS Public API 엔드포인트에 접근할 수 있는 IP 대역을 특정 CIDR로 제한했다. 
허용된 IP 외의 모든 외부 접근이 차단된다.

## 왜 이렇게 만들었나요? (Why)
public_access_cidrs를 설정하지 않으면 기본값이 0.0.0.0/0으로 전 세계 누구나 EKS API 서버에 접근 시도가 가능하다. 최소 권한 원칙에 따라 관리자 IP 대역만 허용함으로써 공격 표면을 최소화한다. 

## 테스트
### Step 1. 현재 취약점 확인 : 전체 IP 허용 상태

`aws eks describe-cluster \
  --name eks-secure-infra-dev \
  --region ap-northeast-2 \
  --query "cluster.resourcesVpcConfig.publicAccessCidrs"`

`["0.0.0.0/0"]` 출력되면 → 전체 허용 상태, 취약점 확인

<img width="498" height="149" alt="image (20)" src="https://github.com/user-attachments/assets/191e15dc-244f-4614-a673-3cab9274d553" />


---

### Step 2. 현재 내 IP 확인 (락아웃 방지)

`curl ifconfig.me`

이 IP를 반드시 `public_access_cidrs`에 포함해야 함

<img width="476" height="41" alt="image (19)" src="https://github.com/user-attachments/assets/304f45fa-838c-4a97-9f0c-592f1ee53652" />


---

### Step 3. Terraform 변수 설정 후 적용

`cd environments/infra`

접속 허용할 공인 IP를 식별하고 등록

`terraform apply \
  -var='public_access_cidrs=["<실습환경IP>/32"]'`

<img width="464" height="72" alt="image (18)" src="https://github.com/user-attachments/assets/992642e5-7a27-4ad7-9343-43747e29599f" />
<img width="394" height="249" alt="image (17)" src="https://github.com/user-attachments/assets/06a8fbef-f348-4fcf-8716-6072bbee5035" />


---

### Step 4. CIDR 제한 적용 확인

`aws eks describe-cluster \
  --name eks-secure-infra-dev \
  --region ap-northeast-2 \
  --query "cluster.resourcesVpcConfig.publicAccessCidrs"`

허용한 CIDR 목록만 출력되면 → 적용 완료

<img width="640" height="141" alt="image (16)" src="https://github.com/user-attachments/assets/da1a4b25-b997-42ae-9fb2-e2ac7a7ca6c0" />


---

### Step 5. 차단 동작 확인

다른 네트워크나 VPN으로 전환 후 테스트

`kubectl get nodes -> 차단됨`

---

