### PR TITLE
[Feat] Public API endpoint 접근 CIDR 제한 (team-d)

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -16,13 +16,14 @@ module "vpc" {
 module "eks" {
   source = "../../modules/eks"
 
-  project_name       = var.project_name
-  environment        = var.environment
-  owner              = var.owner
-  cluster_subnet_ids = module.vpc.private_subnet_ids
-  node_subnet_ids    = module.vpc.public_subnet_ids
-  kubernetes_version = var.kubernetes_version
-  node_ami_type      = var.node_ami_type
-  node_group         = var.node_group
-  default_tags       = var.default_tags
+  project_name                = var.project_name
+  environment                 = var.environment
+  owner                       = var.owner
+  cluster_subnet_ids          = module.vpc.private_subnet_ids
+  node_subnet_ids             = module.vpc.public_subnet_ids
+  cluster_public_access_cidrs = var.cluster_public_access_cidrs
+  kubernetes_version          = var.kubernetes_version
+  node_ami_type               = var.node_ami_type
+  node_group                  = var.node_group
+  default_tags                = var.default_tags
 }

--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -20,6 +20,10 @@ private_subnet_cidrs = [
   "10.0.20.0/24",
 ]
 
+cluster_public_access_cidrs = [
+  "115.136.89.40/32",
+]
+
 fck_nat_instance_type = "t4g.nano"
 
 default_tags = {

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -38,6 +38,11 @@ variable "private_subnet_cidrs" {
   type        = list(string)
 }
 
+variable "cluster_public_access_cidrs" {
+  description = "CIDR blocks allowed to access the dev EKS public API endpoint."
+  type        = list(string)
+}
+
 variable "fck_nat_instance_type" {
   description = "Instance type for the fck-nat instance."
   type        = string

--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -16,13 +16,14 @@ module "vpc" {
 module "eks" {
   source = "../../modules/eks"
 
-  project_name       = var.project_name
-  environment        = var.environment
-  owner              = var.owner
-  cluster_subnet_ids = module.vpc.private_subnet_ids
-  node_subnet_ids    = module.vpc.public_subnet_ids
-  kubernetes_version = var.kubernetes_version
-  node_ami_type      = var.node_ami_type
-  node_group         = var.node_group
-  default_tags       = var.default_tags
+  project_name                = var.project_name
+  environment                 = var.environment
+  owner                       = var.owner
+  cluster_subnet_ids          = module.vpc.private_subnet_ids
+  node_subnet_ids             = module.vpc.public_subnet_ids
+  cluster_public_access_cidrs = var.cluster_public_access_cidrs
+  kubernetes_version          = var.kubernetes_version
+  node_ami_type               = var.node_ami_type
+  node_group                  = var.node_group
+  default_tags                = var.default_tags
 }

--- a/environments/infra/terraform.tfvars
+++ b/environments/infra/terraform.tfvars
@@ -20,6 +20,10 @@ private_subnet_cidrs = [
   "10.0.20.0/24",
 ]
 
+cluster_public_access_cidrs = [
+  "115.136.89.40/32",
+]
+
 fck_nat_instance_type = "t4g.nano"
 
 default_tags = {

--- a/environments/infra/variables.tf
+++ b/environments/infra/variables.tf
@@ -38,6 +38,11 @@ variable "private_subnet_cidrs" {
   type        = list(string)
 }
 
+variable "cluster_public_access_cidrs" {
+  description = "CIDR blocks allowed to access the infra EKS public API endpoint."
+  type        = list(string)
+}
+
 variable "fck_nat_instance_type" {
   description = "Instance type for the fck-nat instance."
   type        = string

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -104,6 +104,7 @@ resource "aws_eks_cluster" "this" {
     subnet_ids              = var.cluster_subnet_ids
     endpoint_private_access = true
     endpoint_public_access  = true
+    public_access_cidrs     = var.cluster_public_access_cidrs
   }
 
   depends_on = [

--- a/modules/eks/tests/minimal-cluster.tftest.hcl
+++ b/modules/eks/tests/minimal-cluster.tftest.hcl
@@ -16,6 +16,9 @@ variables {
   node_subnet_ids    = ["subnet-public-a", "subnet-public-b"]
   kubernetes_version = "1.34"
   node_ami_type      = "AL2023_ARM_64_STANDARD"
+  cluster_public_access_cidrs = [
+    "115.136.89.40/32",
+  ]
 
   node_group = {
     instance_types = ["t4g.medium"]
@@ -47,6 +50,21 @@ run "plan_builds_minimal_eks_cluster" {
   assert {
     condition     = length(setsubtract(toset(aws_eks_cluster.this.vpc_config[0].subnet_ids), toset(var.cluster_subnet_ids))) == 0
     error_message = "The EKS control plane must stay on the private cluster subnets."
+  }
+
+  assert {
+    condition     = aws_eks_cluster.this.vpc_config[0].endpoint_private_access && aws_eks_cluster.this.vpc_config[0].endpoint_public_access
+    error_message = "The EKS cluster must keep both private and public API endpoint access enabled for the transition phase."
+  }
+
+  assert {
+    condition     = length(setsubtract(toset(var.cluster_public_access_cidrs), toset(aws_eks_cluster.this.vpc_config[0].public_access_cidrs))) == 0
+    error_message = "The EKS public API endpoint must be restricted to the configured public access CIDRs."
+  }
+
+  assert {
+    condition     = !contains(aws_eks_cluster.this.vpc_config[0].public_access_cidrs, "0.0.0.0/0")
+    error_message = "The EKS public API endpoint must not allow 0.0.0.0/0."
   }
 
   assert {

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -33,6 +33,21 @@ variable "node_subnet_ids" {
   }
 }
 
+variable "cluster_public_access_cidrs" {
+  description = "CIDR blocks allowed to access the EKS public API endpoint."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.cluster_public_access_cidrs) > 0
+    error_message = "At least one CIDR must be supplied for the EKS public API endpoint."
+  }
+
+  validation {
+    condition     = !contains(var.cluster_public_access_cidrs, "0.0.0.0/0") && !contains(var.cluster_public_access_cidrs, "::/0")
+    error_message = "Do not allow 0.0.0.0/0 or ::/0 for the EKS public API endpoint."
+  }
+}
+
 variable "kubernetes_version" {
   description = "Kubernetes version for the EKS cluster and managed node group."
   type        = string


### PR DESCRIPTION
## 관련 이슈
- Closes #11 

## 무엇을 만들었나요? (What)
- EKS 모듈에 `cluster_public_access_cidrs` 입력값을 추가하고 `aws_eks_cluster.vpc_config.public_access_cidrs`에 연결함
- `0.0.0.0/0`, `::/0` 과 같은 전체 공개 CIDR을 변수 validation으로 차단함
- `infra`와 `dev` 환경에 현재 실습용 CIDR인 `115.136.89.40/32`를 설정함

## 왜 이렇게 만들었나요? (Why)
- `0.0.0.0/0`, `::/0` 과 같은 전체 공개 CIDR을 허용해두면 운영 편의성이 높지만 공격 표면도 넓어진다.
- 따라서 임시로 현재 실습 IP를 추가하여, 해당 IP만 접속할 수 있도록 설정한다.
- 이는 IP의 변동 사항을 고려한 설계가 아니므로 VPN 혹은 고정 IP(Bastion Host)를 이용하여 접속할 수 있도록 추가로 작업할 예정이다.

## 테스트

```
aws eks describe-cluster \
  --name eks-secure-infra-dev \
  --region ap-northeast-2 \
  --query 'cluster.resourcesVpcConfig.{endpointPublicAccess:endpointPublicAccess,endpointPrivateAccess:endpointPrivateAccess,publicAccessCidrs:publicAccessCidrs}' \
  --output json
```

<img width="357" height="120" alt="스크린샷 2026-04-27 오후 4 09 52" src="https://github.com/user-attachments/assets/eeea85ee-8861-4ab2-831b-403e9860cf2d" />

현재 AWS의 EKS에 설정된 CIDR은 0.0.0.0/0 (전체 공개)이다.

<img width="783" height="430" alt="스크린샷 2026-04-27 오후 4 10 42" src="https://github.com/user-attachments/assets/ee7b47aa-985b-4ec5-be06-378beb569b0a" />

적용 이후 EKS cluster의 public_access_cidr이 현재 실습용 CIDR인 `115.136.89.40/32`만 허용하는 것을 확인할 수 있다.
해당 내용은 apply하면 다른 팀원이 접속하지 못하므로 실제로 적용하지는 않았고, terraform plan 단계에서 적용을 확인하였다.