### PR TITLE
[Feat] Ingress와 LB에 TLS 강제 (team-a)

### DIFF
--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -23,6 +23,7 @@ module "k8s_base" {
   aws_node_termination_handler_chart_version = var.aws_node_termination_handler_chart_version
   ingress_nginx_namespace                    = var.ingress_nginx_namespace
   ingress_nginx_chart_version                = var.ingress_nginx_chart_version
+  ingress_lb_acm_certificate_arn             = var.ingress_lb_acm_certificate_arn
 }
 
 module "namespaces" {

--- a/environments/platform/terraform.tfvars
+++ b/environments/platform/terraform.tfvars
@@ -12,3 +12,5 @@ ingress_nginx_chart_version  = "4.14.1"
 argocd_chart_version         = "9.4.17"
 argocd_apps_chart_version    = "2.0.3"
 gitops_repo_url              = "https://github.com/K8RVIS/eks-secure-infra.git"
+
+ingress_lb_acm_certificate_arn = "arn:aws:acm:ap-northeast-2:357542025037:certificate/6e95b8cb-8e7a-44ac-a47d-be12cf7a413b"

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -124,3 +124,8 @@ variable "team_names" {
   type        = list(string)
   default     = ["team-a", "team-b", "team-c", "team-d"]
 }
+
+variable "ingress_lb_acm_certificate_arn" {
+  description = "ACM certificate ARN used by the ingress-nginx AWS load balancer TLS listener."
+  type        = string
+}

--- a/manifests/overlays/team-a/web-ingress-patch.yaml
+++ b/manifests/overlays/team-a/web-ingress-patch.yaml
@@ -2,9 +2,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
+  tls:
+  - hosts:
+      - team-a.terraform-study-esc.shop
+    secretName: team-a-web-tls
   rules:
-    - host: team-a.training.local
+    - host: team-a.terraform-study-esc.shop
       http:
         paths:
           - path: /

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -62,6 +62,11 @@ resource "helm_release" "ingress_nginx" {
         type: LoadBalancer
         annotations:
           service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+          service.beta.kubernetes.io/aws-load-balancer-type: external
+          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: ${var.ingress_lb_acm_certificate_arn}
+          //service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+          service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
     EOT
   ]
 }

--- a/modules/k8s-base/variables.tf
+++ b/modules/k8s-base/variables.tf
@@ -45,3 +45,8 @@ variable "ingress_nginx_chart_version" {
   type        = string
   default     = "4.14.1"
 }
+
+variable "ingress_lb_acm_certificate_arn" {
+  description = "ACM certificate ARN used by the ingress-nginx AWS load balancer TLS listener."
+  type        = string
+}


### PR DESCRIPTION
## 관련 이슈
- Closes https://github.com/K8RVIS/eks-secure-infra/issues/9

## 무엇을 만들었나요? (What)
- ingress-nginx LB Service에 ACM 인증서 기반 TLS 리스너 설정을 추가했다.
- Platform에서 ACM 인증서 ARN을 입력받아 k8s-base 모듈로 전달하도록 변수를 추가했다.
- team-a Ingress에 외부 도메인 team-a.terraform-study-esc.shop을 적용하고, TLS 설정과 HTTP에서 HTTPS로의 redirect annotation을 추가했다.

## 왜 이렇게 만들었나요? (Why)
- 외부 사용자가 team-a.terraform-study-esc.shop에 접속할 때 LB에서 ACM 인증서를 사용해 HTTPS 통신을 제공하기 위해서이다. 
- HTTP 요청이 그대로 서비스로 전달되지 않고 HTTPS로 전환되도록 Ingress nginx의 redirect 설정을 추가했다.
- ACM 인증서 ARN을 하드코딩하지 않고 Terraform 변수로 분리해 환경별 인증서 교체가 가능하도록 했다.
- Ingress에 명시적인 TLS host를 추가하여 HTTPS 라우팅과 redirect 동작이 가능하도록 하였다. 

## 테스트
### 패치 적용 전 상태 확인

<img width="986" height="593" alt="스크린샷 2026-04-27 212810" src="https://github.com/user-attachments/assets/97257f19-9c31-45dd-aabc-1f00f7f208e3" />

다음과 같이 ingress를 확인하여 ssl-redirect annotation이 없는 것을 알 수 있다. 

<img width="665" height="951" alt="스크린샷 2026-04-27 213050" src="https://github.com/user-attachments/assets/8c3424d0-9983-45d9-9552-fa6fd513aec1" />

AWS LB Service를 확인해보면 type을 통해 LoadBalancer가 맞는 것을 확인할 수 있고, AWS LB TLS 관련 annotation이 없으며 80번, 443번 포트가 노출된 것을 알 수 있다. 

<img width="1072" height="192" alt="스크린샷 2026-04-27 215500" src="https://github.com/user-attachments/assets/49e6574e-8af0-4371-b190-1be87332a639" />

다음과 같이 AWS LB에 실제로 443 TLS 리스너가 생긴 것을 알 수 있다. 
### 패치 적용 후 상태 확인 

<img width="316" height="176" alt="스크린샷 2026-04-27 224127" src="https://github.com/user-attachments/assets/dee00b06-c552-42b4-828d-eb4d9925170c" />

이를 통해 ACN 인증서의 도메인과 실제 접속 도메인이 일치하는 것을 확인할 수 있다. 

<img width="504" height="126" alt="스크린샷 2026-04-27 230016" src="https://github.com/user-attachments/assets/46c3dda2-31e9-4b2c-a951-d68eb347e858" />

80포트로 요청이 들어오더라도 redirect 되는 것을 확인할 수 있다. 

<img width="509" height="31" alt="스크린샷 2026-04-27 231558" src="https://github.com/user-attachments/assets/dc4d5ccc-e880-4de0-8ba4-2287543fab0c" />

이를 통해 Ingress가 외부 도메인을 기준으로 라우팅 하도록 설정된 것을 알 수 있다. 

## 참고

