### PR TITLE
[Feat] Public API endpoint 접근 CIDR 제한 (team-a)

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -25,4 +25,6 @@ module "eks" {
   node_ami_type      = var.node_ami_type
   node_group         = var.node_group
   default_tags       = var.default_tags
+  cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
+
 }

--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -38,3 +38,7 @@ node_group = {
   max_size       = 3
   disk_size_gb   = 20
 }
+
+cluster_endpoint_public_access_cidrs = [
+  "203.0.113.10/32", # 접근 허용할 CIDR 값 넣기
+]

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -18,6 +18,11 @@ variable "owner" {
   type        = string
 }
 
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "CIDR blocks allowed to access the EKS public API endpoint."
+  type        = list(string)
+}
+
 variable "vpc_cidr" {
   description = "CIDR block for the dev VPC."
   type        = string

--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -25,4 +25,5 @@ module "eks" {
   node_ami_type      = var.node_ami_type
   node_group         = var.node_group
   default_tags       = var.default_tags
+  cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
 }

--- a/environments/infra/terraform.tfvars
+++ b/environments/infra/terraform.tfvars
@@ -38,3 +38,7 @@ node_group = {
   max_size       = 3
   disk_size_gb   = 20
 }
+
+cluster_endpoint_public_access_cidrs = [
+  "203.0.113.10/32", # 접근 허용할 CIDR 값 넣기
+]

--- a/environments/infra/variables.tf
+++ b/environments/infra/variables.tf
@@ -18,6 +18,11 @@ variable "owner" {
   type        = string
 }
 
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "CIDR blocks allowed to access the EKS public API endpoint."
+  type        = list(string)
+}
+
 variable "vpc_cidr" {
   description = "CIDR block for the infra VPC."
   type        = string

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -104,6 +104,7 @@ resource "aws_eks_cluster" "this" {
     subnet_ids              = var.cluster_subnet_ids
     endpoint_private_access = true
     endpoint_public_access  = true
+    public_access_cidrs     = var.cluster_endpoint_public_access_cidrs
   }
 
   depends_on = [

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -79,3 +79,28 @@ variable "default_tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "CIDR blocks allowed to access the EKS public API endpoint."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.cluster_endpoint_public_access_cidrs) > 0
+    error_message = "At least one CIDR block must be supplied for the EKS public API endpoint."
+  }
+
+  validation {
+    condition = alltrue([
+      for cidr in var.cluster_endpoint_public_access_cidrs : can(cidrhost(cidr, 0))
+    ])
+    error_message = "Each EKS public API endpoint CIDR must be a valid CIDR block."
+  }
+
+  validation {
+    condition = alltrue([
+      for cidr in var.cluster_endpoint_public_access_cidrs :
+      !contains(["0.0.0.0/0", "::/0"], cidr)
+    ])
+    error_message = "Unrestricted access to the EKS public API endpoint is not allowed."
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes https://github.com/K8RVIS/eks-secure-infra/issues/11

## 무엇을 만들었나요? (What)
- EKS Public API endpoint 접근 범위를 제한하기 위해 public_access_cidrs 설정을 추가하였다.
- modules/eks에 cluster_endpoint_public_access_cidrs 입력 변수를 추가하고 전체 공개 CIDR인 0.0.0.0/0, ::/0이 입력되지 않도록 validation을 추가하였다.

## 왜 이렇게 만들었나요? (Why)
- 기존 구성은 EKS Public API endpoint가 활성화되어 있지만 접근 허용 CIDR이 명시되어 있지 않아, 의도보다 넓은 범위에서 Kubernetes API Server에 접근 가능할 위험이 있었고, CIDR 값을 모듈 내부에 하드코딩하지 않고 environment 입력 변수로 분리하여, 상황에 맞게 다르게 설정할 수 있도록 구성하였다.

## 테스트

### 1. 패치를 진행할 곳 확인하기
<img width="956" height="425" alt="스크린샷 2026-04-28 013106" src="https://github.com/user-attachments/assets/89a766a8-b24c-4f75-85c3-cb3943458749" />

위와 같은 결과를 통해 EKS 클러스터 설정 중, Public API 접근과 관려된 코드 위치를 찾을 수 있다. 출력 내용을 참고하여 
`endpoint_public_access = true`는 보이지만 `public_access_cidrs`가 안 보이면, 현재 Public endpoint CIDR 제한이 코드에 없다는 점을 명확히 확인할 수 있다.  따라서 이러한 부분에 대해 패치를 진행한다. 

### 2. 패치 적용 전 
<img width="902" height="192" alt="image" src="https://github.com/user-attachments/assets/e45c3307-4a7b-4370-8d1f-a9693533b8e9" />
모든 공용 IP로부터 접근이 가능한 것을 확인할 수 있다. 

### 3 패치 적용 후
<img width="880" height="525" alt="image" src="https://github.com/user-attachments/assets/3aa1b6d5-31cd-4e3b-884e-7b6288dde0cb" />
패치를 통해 수정한 내용이 모두 반영된 것을 확인할 수 있다. 

## 참고
실제 테스트를 위해서는 terraform apply를 해야하지만 실습환경과 충돌로 인해 변경사항이 모두 반영되었음을 확인하였음