### PR TITLE
[feat] Cluster Resource 제한 (team-b)

### DIFF
--- a/environments/platform/.terraform.lock.hcl
+++ b/environments/platform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 5.0"
   hashes = [
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",

--- a/modules/namespaces/main.tf
+++ b/modules/namespaces/main.tf
@@ -9,3 +9,45 @@ resource "kubernetes_namespace_v1" "teams" {
     }
   }
 }
+
+resource "kubernetes_resource_quota" "teams" {
+  for_each = kubernetes_namespace_v1.teams
+
+  metadata {
+    name      = "team-quota"
+    namespace = each.value.metadata[0].name
+  }
+
+  spec {
+    hard = {
+      "requests.cpu"    = "1"
+      "limits.cpu"      = "2"
+      "requests.memory" = "1Gi"
+      "limits.memory"   = "2Gi"
+      "pods"            = "10"
+    }
+  }
+}
+
+resource "kubernetes_limit_range" "teams" {
+  for_each = kubernetes_namespace_v1.teams
+
+  metadata {
+    name      = "team-limit-range"
+    namespace = each.value.metadata[0].name
+  }
+
+  spec {
+    limit {
+      type = "Container"
+      default = {
+        cpu    = "500m"
+        memory = "256Mi"
+      }
+      default_request = {
+        cpu    = "100m"
+        memory = "128Mi"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #12 

## 무엇을 만들었나요? (What)
`modules/namespaces/main.tf`에 `ResourceQuota`와 `LimitRange` 두 가지 리소스를 추가했다.  team-b 네임스페이스에 CPU/메모리 사용량 제한이 적용되게 하여 리소스 값을 제한한다.
- **ResouceQuotaq** : 네임스페이스 전체 최대 사용량 제한 / CPU 2코어, Memory 2Gi, Pod 10개
- **LimitRange** : Pod 개별 기본값 강제 / CPU 500m|Memory 256Mi (limit), CPU 100m|Memory 128Mi 

## 왜 이렇게 만들었나요? (Why)
특정 서비스의 자원 고갈(DoS 공격 또는 설정 오류)로 인해 클러스터 전체 가용성이 무너지는 것을 방지하기 위함이다. ResourceQuota로 네임스페이스 단위 총량을 물리적으로 제한하고, LimitRange로 개별 Pod에 기본 제한값을 자동 부여해 resources 미설정 Pod도 제한 범위 안에서만 동작하게 강제한다.

## 테스트
### Step 1. 현재 취약점 확인

`kubectl get resourcequota -n team-b
kubectl get limitrange -n team-b`

아무것도 없으면 → 리소스 제한 없음, 무제한 사용 가능한 취약 상태

<img width="547" height="126" alt="image (25)" src="https://github.com/user-attachments/assets/3d1d55eb-0a7c-40c3-8db4-1a404353562a" />


---

### Step 2. Terraform 적용

`cd environments/platform
terraform apply`

---

### Step 3. Quota 적용 확인

`kubectl get resourcequota -n team-b
kubectl describe resourcequota team-quota -n team-b

kubectl get limitrange -n team-b
kubectl describe limitrange team-limit-range -n team-b`

설정한 CPU/Memory 제한값이 출력되면 적용 완료

<img width="700" height="493" alt="image (24)" src="https://github.com/user-attachments/assets/00ad895a-52ac-431c-9f6e-466c83579f64" />


---

### Step 4. Quota 초과 시 에러 확인 (타이트한 설정 테스트)

Pod를 quota 한계까지 스케일

`kubectl scale deployment api --replicas=20 -n team-b`

`kubectl get pods -n team-b`

`kubectl describe resourcequota team-quota -n team-b`

<img width="661" height="395" alt="image (23)" src="https://github.com/user-attachments/assets/33ac7e5d-c07e-4d6e-9086-0f3f8ed9d291" />


→ Pending 되어서 막힌거 확인!

`kubectl get events -n team-b | grep -i quota`

`exceeded quota` 에러 출력 → Quota가 초과 배포를 물리적으로 차단하는 것 확인

<img width="707" height="544" alt="image (22)" src="https://github.com/user-attachments/assets/b1b91b2c-2b3c-49e1-a398-9acd8c46198a" />


---

### Step 5. 정상 범위 내 동작 확인

정상 범위로 되돌리기

`kubectl scale deployment api --replicas=1 -n team-b`

`kubectl get pods -n team-b`

<img width="675" height="141" alt="image (21)" src="https://github.com/user-attachments/assets/27e94f75-e865-4448-9f6a-da230526799c" />
