### PR TITLE
[Feat] Workload 내 Hardcoded Secret 제거 (team-d)

### DIFF
--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -12,6 +12,51 @@ data "aws_eks_cluster_auth" "infra" {
   name = data.terraform_remote_state.infra.outputs.cluster_name
 }
 
+data "aws_iam_policy_document" "external_secrets_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "external_secrets_access" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+    ]
+
+    resources = var.external_secrets_secret_arns
+  }
+}
+
+resource "aws_eks_addon" "pod_identity_agent" {
+  cluster_name = data.terraform_remote_state.infra.outputs.cluster_name
+  addon_name   = "eks-pod-identity-agent"
+}
+
+resource "aws_iam_role" "external_secrets" {
+  name               = "${data.terraform_remote_state.infra.outputs.cluster_name}-external-secrets"
+  assume_role_policy = data.aws_iam_policy_document.external_secrets_assume_role.json
+}
+
+resource "aws_iam_role_policy" "external_secrets" {
+  name   = "read-workload-runtime-secrets"
+  role   = aws_iam_role.external_secrets.id
+  policy = data.aws_iam_policy_document.external_secrets_access.json
+}
+
 module "k8s_base" {
   source = "../../modules/k8s-base"
 
@@ -23,6 +68,25 @@ module "k8s_base" {
   aws_node_termination_handler_chart_version = var.aws_node_termination_handler_chart_version
   ingress_nginx_namespace                    = var.ingress_nginx_namespace
   ingress_nginx_chart_version                = var.ingress_nginx_chart_version
+  external_secrets_namespace                 = var.external_secrets_namespace
+  external_secrets_chart_version             = var.external_secrets_chart_version
+  external_secrets_service_account_name      = var.external_secrets_service_account_name
+
+  depends_on = [
+    aws_eks_pod_identity_association.external_secrets,
+  ]
+}
+
+resource "aws_eks_pod_identity_association" "external_secrets" {
+  cluster_name    = data.terraform_remote_state.infra.outputs.cluster_name
+  namespace       = var.external_secrets_namespace
+  service_account = var.external_secrets_service_account_name
+  role_arn        = aws_iam_role.external_secrets.arn
+
+  depends_on = [
+    aws_eks_addon.pod_identity_agent,
+    aws_iam_role_policy.external_secrets,
+  ]
 }
 
 module "namespaces" {
@@ -47,5 +111,9 @@ module "argocd" {
   gitops_applications_base_path = var.gitops_applications_base_path
   team_names                    = var.team_names
 
-  depends_on = [module.k8s_base, module.namespaces]
+  depends_on = [
+    module.k8s_base,
+    module.namespaces,
+    aws_eks_pod_identity_association.external_secrets,
+  ]
 }

--- a/environments/platform/outputs.tf
+++ b/environments/platform/outputs.tf
@@ -38,6 +38,21 @@ output "ingress_service_name" {
   value       = module.k8s_base.ingress_service_name
 }
 
+output "external_secrets_release_name" {
+  description = "Helm release name for External Secrets Operator."
+  value       = module.k8s_base.external_secrets_release_name
+}
+
+output "external_secrets_namespace" {
+  description = "Namespace where External Secrets Operator is deployed."
+  value       = module.k8s_base.external_secrets_namespace
+}
+
+output "external_secrets_role_arn" {
+  description = "IAM role ARN associated with the External Secrets Operator service account."
+  value       = aws_iam_role.external_secrets.arn
+}
+
 output "team_namespace_names" {
   description = "Created team namespace names."
   value       = module.namespaces.namespace_names

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -77,6 +77,30 @@ variable "ingress_nginx_chart_version" {
   default     = "4.14.1"
 }
 
+variable "external_secrets_namespace" {
+  description = "Namespace used for the External Secrets Operator release."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "external_secrets_chart_version" {
+  description = "Pinned chart version for External Secrets Operator. Set to null to use the repository default."
+  type        = string
+  default     = null
+}
+
+variable "external_secrets_service_account_name" {
+  description = "ServiceAccount name used by External Secrets Operator."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "external_secrets_secret_arns" {
+  description = "Secrets Manager ARNs that External Secrets Operator can read for workload runtime secrets."
+  type        = list(string)
+  default     = ["arn:aws:secretsmanager:*:*:secret:/eks-secure-infra/app/*"]
+}
+
 variable "argocd_namespace" {
   description = "Namespace used for the ArgoCD installation."
   type        = string

--- a/manifests/base/api/deployment.yaml
+++ b/manifests/base/api/deployment.yaml
@@ -22,8 +22,13 @@ spec:
         - name: api
           image: ealen/echo-server
           env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-runtime-secrets
+                  key: REDIS_PASSWORD
             - name: REDIS_URL
-              value: redis://:training-password@db:6379/0
+              value: redis://:$(REDIS_PASSWORD)@db:6379/0
             - name: EXTERNAL_POSTGRES_HOST
               value: reporting-db.training.local
             - name: EXTERNAL_POSTGRES_PORT
@@ -33,7 +38,10 @@ spec:
             - name: EXTERNAL_POSTGRES_USER
               value: training-api
             - name: EXTERNAL_POSTGRES_PASSWORD
-              value: training-external-password
+              valueFrom:
+                secretKeyRef:
+                  name: app-runtime-secrets
+                  key: EXTERNAL_POSTGRES_PASSWORD
           ports:
             - containerPort: 80
               name: http

--- a/manifests/base/db/statefulset.yaml
+++ b/manifests/base/db/statefulset.yaml
@@ -27,7 +27,10 @@ spec:
             - redis-server --appendonly yes --requirepass "$REDIS_PASSWORD"
           env:
             - name: REDIS_PASSWORD
-              value: training-password
+              valueFrom:
+                secretKeyRef:
+                  name: app-runtime-secrets
+                  key: REDIS_PASSWORD
           ports:
             - containerPort: 6379
               name: redis

--- a/manifests/base/runtime-secrets/externalsecret.yaml
+++ b/manifests/base/runtime-secrets/externalsecret.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: app-secrets-manager
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: ap-northeast-2
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-runtime-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: app-secrets-manager
+    kind: SecretStore
+  target:
+    name: app-runtime-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: REDIS_PASSWORD
+      remoteRef:
+        key: /eks-secure-infra/app/redis
+        property: password
+    - secretKey: EXTERNAL_POSTGRES_PASSWORD
+      remoteRef:
+        key: /eks-secure-infra/app/external-postgres
+        property: password

--- a/manifests/base/runtime-secrets/kustomization.yaml
+++ b/manifests/base/runtime-secrets/kustomization.yaml
@@ -2,7 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - runtime-secrets
-  - web
-  - api
-  - db
+  - externalsecret.yaml

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -65,3 +65,26 @@ resource "helm_release" "ingress_nginx" {
     EOT
   ]
 }
+
+resource "helm_release" "external_secrets" {
+  name             = "external-secrets"
+  namespace        = var.external_secrets_namespace
+  create_namespace = true
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  version          = var.external_secrets_chart_version
+  timeout          = var.helm_release_timeout_seconds
+  atomic           = true
+  cleanup_on_fail  = true
+  wait             = true
+
+  values = [
+    yamlencode({
+      installCRDs = true
+      serviceAccount = {
+        create = true
+        name   = var.external_secrets_service_account_name
+      }
+    })
+  ]
+}

--- a/modules/k8s-base/outputs.tf
+++ b/modules/k8s-base/outputs.tf
@@ -22,3 +22,13 @@ output "ingress_service_name" {
   description = "Service name exposed by ingress-nginx."
   value       = "${helm_release.ingress_nginx.name}-controller"
 }
+
+output "external_secrets_release_name" {
+  description = "Helm release name for External Secrets Operator."
+  value       = helm_release.external_secrets.name
+}
+
+output "external_secrets_namespace" {
+  description = "Namespace where External Secrets Operator is deployed."
+  value       = helm_release.external_secrets.namespace
+}

--- a/modules/k8s-base/tests/core-addons.tftest.hcl
+++ b/modules/k8s-base/tests/core-addons.tftest.hcl
@@ -3,7 +3,7 @@ mock_provider "helm" {
 }
 
 variables {
-  metrics_server_chart_version        = "3.13.0"
+  metrics_server_chart_version       = "3.13.0"
   ingress_nginx_chart_version        = "4.14.1"
   aws_node_termination_handler_chart = "aws-node-termination-handler"
 }
@@ -59,5 +59,25 @@ run "plan_deploys_core_addons" {
   assert {
     condition     = output.ingress_service_name == "ingress-nginx-controller"
     error_message = "The module must expose the ingress controller service name."
+  }
+
+  assert {
+    condition     = helm_release.external_secrets.name == "external-secrets"
+    error_message = "External Secrets Operator release must use the expected release name."
+  }
+
+  assert {
+    condition     = helm_release.external_secrets.repository == "https://charts.external-secrets.io"
+    error_message = "External Secrets Operator must use the official helm repository."
+  }
+
+  assert {
+    condition     = helm_release.external_secrets.chart == "external-secrets"
+    error_message = "External Secrets Operator must install the external-secrets chart."
+  }
+
+  assert {
+    condition     = helm_release.external_secrets.namespace == var.external_secrets_namespace
+    error_message = "External Secrets Operator must deploy into the configured namespace."
   }
 }

--- a/modules/k8s-base/variables.tf
+++ b/modules/k8s-base/variables.tf
@@ -45,3 +45,21 @@ variable "ingress_nginx_chart_version" {
   type        = string
   default     = "4.14.1"
 }
+
+variable "external_secrets_namespace" {
+  description = "Namespace used for the External Secrets Operator release."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "external_secrets_chart_version" {
+  description = "Pinned chart version for External Secrets Operator. Set to null to use the repository default."
+  type        = string
+  default     = null
+}
+
+variable "external_secrets_service_account_name" {
+  description = "ServiceAccount name used by External Secrets Operator."
+  type        = string
+  default     = "external-secrets"
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #32 

## 무엇을 만들었나요? (What)
- 워크로드 매니페스트에 하드코딩되어 있던 `training-password`, `training-external-password` 제거
- `api` Deployment와 `db` StatefulSet이 `app-runtime-secrets` Kubernetes Secret을 `secretKeyRef`로 참조하도록 변경
- Secrets Manager 값을 Kubernetes Secret으로 동기화하기 위한 `SecretStore`와 `ExternalSecret` 추가
- External Secrets Operator를 `k8s-base` Helm으로 추가
- External Secrets Operator가 Secrets Manager를 읽을 수 있도록 EKS Pod Identity Agent, IAM Role/Policy, Pod Identity Association 추가

## 왜 이렇게 만들었나요? (Why)
- Secret 값이 Git, 이미지 레이어, 배포 매니페스트, CI/CD 로그에 남으면 삭제 이후에도 장기간 노출될 수 있다.
- 워크로드에는 실제 Secret 값이 아니라 참조만 남기고, 원본 값은 AWS Secrets Manager에서 관리하도록 분리했다.
- 기존 앱 구조를 크게 바꾸지 않기 위해 환경변수 주입 방식은 유지하되, 평문 `value` 대신 `secretKeyRef`를 사용했다.
- External Secrets Operator와 Pod Identity를 함께 사용해 Kubernetes 매니페스트에 Secret 값을 저장하지 않고, AWS 권한도 최소 범위로 제한하도록 구성했다.

## 테스트

### 적용 전

<img width="659" height="305" alt="스크린샷 2026-04-28 오후 12 14 45" src="https://github.com/user-attachments/assets/932f265b-3efb-416f-8518-4f5dee7ebe42" />

db/statefulset.yaml에 REDIS_PASSWORD가 평문으로 노출되어 있다.

<img width="1026" height="884" alt="image" src="https://github.com/user-attachments/assets/b3765d82-d838-463e-8863-1d57cb3edb77" />

api/deployment.yaml에 REDIS_URL과 EXTERNAL_POSTGRES_PASSWORD이 평문으로 노출되어 있다.

### 적용 후

<img width="1478" height="112" alt="image" src="https://github.com/user-attachments/assets/3a168058-3858-47c7-8252-8df0724ef7b8" />
<img width="1528" height="204" alt="image" src="https://github.com/user-attachments/assets/9d45b2bc-52e8-45db-a1f0-5b311bde8bd3" />

REDIS_PASSWORD를 Secret Manager에서 관리하고 있다.

<img width="1474" height="106" alt="image" src="https://github.com/user-attachments/assets/a548338e-748a-4feb-908c-fd0106bfb14a" />
<img width="1626" height="210" alt="image" src="https://github.com/user-attachments/assets/e2371176-ba65-401d-8cf9-258b23bc8edc" />

EXTERNAL_POSTGRES_PASSWORD를 Secret Manager에서 관리하고 있다.

<img width="1638" height="514" alt="image" src="https://github.com/user-attachments/assets/ffbc8cd5-dec0-4a94-aabf-27db7a1ec773" />
<img width="1636" height="904" alt="image" src="https://github.com/user-attachments/assets/430de62d-bcf0-4026-bc43-3893a75d674e" />

REDIS_PASSWORD, EXTERNAL_POSTGRES_PASSWORD를 평문으로 사용하지 않고, secretKeyRef를 통해 참조하고 있다.
이를 통해 원본 값은 Secret Manager에서 관리하고, k8s에서는 secretKeyRef를 통해 참조하기 때문에 Secret 노출의 위험을 줄일 수 있다.

## 참고
- 실제 적용 전 AWS Secrets Manager에 아래 Secret을 먼저 생성해야 한다.
  - `/eks-secure-infra/app/redis`
  - `/eks-secure-infra/app/external-postgres`
