### PR TITLE
[Feat] Cluster Resource 제한 (team-d)

### DIFF
--- a/manifests/overlays/team-d/kustomization.yaml
+++ b/manifests/overlays/team-d/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: team-d
 
 resources:
   - ../../base
+  - resource-controls.yaml
 
 patches:
   - path: web-ingress-patch.yaml

--- a/manifests/overlays/team-d/resource-controls.yaml
+++ b/manifests/overlays/team-d/resource-controls.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-resource-quota
+spec:
+  hard:
+    requests.cpu: "2"
+    requests.memory: 4Gi
+    limits.cpu: "4"
+    limits.memory: 8Gi
+    pods: "20"
+    services: "10"
+    persistentvolumeclaims: "5"
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-container-limits
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+      default:
+        cpu: 500m
+        memory: 512Mi
+      min:
+        cpu: 50m
+        memory: 64Mi
+      max:
+        cpu: "1"
+        memory: 1Gi


### PR DESCRIPTION
## 관련 이슈
- Closes #12

## 무엇을 만들었나요? (What)
- team-d Kustomize overlay에 ResourceQuota, LimitRange 추가

## 왜 이렇게 만들었나요? (Why)
- 팀별 자율 설정만으로는 resource request/limit 누락이나 과도한 값 설정을 막기 어렵다.
- ResourceQuota로 namespace 전체 리소스 사용량을 제한하고, LimitRange로 개별 컨테이너 기본값과 최대값을 강제한다.

## 테스트

### 적용 전

<img width="760" height="121" alt="image" src="https://github.com/user-attachments/assets/0b6ebc20-4e5d-4ee1-a047-63eb69bc6ff2" />

리소스 제한 없음

### 적용 후

<img width="788" height="141" alt="스크린샷 2026-04-28 오후 3 01 06" src="https://github.com/user-attachments/assets/f95a9d1a-fd57-4bb6-86b8-a795e4efb37e" />
<img width="788" height="141" alt="스크린샷 2026-04-28 오후 3 01 06" src="https://github.com/user-attachments/assets/a09a5428-ac0c-44a6-8edd-2ba78c5946e5" />

CPU, 메모리 등 team-d namespace에 리소스 제한 추가