### PR TITLE
[Feat] Container Image 취약점 탐지 (team-d)

### DIFF
--- a/.github/workflows/image-vulnerability-scan.yml
+++ b/.github/workflows/image-vulnerability-scan.yml
@@ -1,0 +1,106 @@
+name: Container Image Vulnerability Scan
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/image-vulnerability-scan.yml"
+      - "manifests/**"
+      - "scripts/list_manifest_images.py"
+      - "tests/test_list_manifest_images.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/image-vulnerability-scan.yml"
+      - "manifests/**"
+      - "scripts/list_manifest_images.py"
+      - "tests/test_list_manifest_images.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: image-vulnerability-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan-images:
+    runs-on: ubuntu-24.04
+    env:
+      TRIVY_SEVERITY: CRITICAL,HIGH
+      TRIVY_REPORT_SEVERITY: CRITICAL,HIGH,MEDIUM
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Verify manifest image extraction
+        run: python -m unittest tests.test_list_manifest_images -v
+
+      - name: Collect images from Kubernetes manifests
+        run: |
+          set -euo pipefail
+          python scripts/list_manifest_images.py manifests > image-list.txt
+
+          if [ ! -s image-list.txt ]; then
+            echo "::error::No container images were found under manifests/."
+            exit 1
+          fi
+
+          echo "Images selected for vulnerability scanning:"
+          cat image-list.txt
+
+      - name: Set up Trivy
+        uses: aquasecurity/setup-trivy@v0.2.6
+        with:
+          version: v0.69.3
+
+      - name: Scan manifest images with Trivy
+        run: |
+          set -euo pipefail
+          mkdir -p trivy-reports
+          scan_status=0
+
+          while IFS= read -r image; do
+            if [ -z "$image" ]; then
+              continue
+            fi
+
+            report_name="$(printf '%s' "$image" | tr '/:@' '____')"
+            echo "::group::Trivy scan: $image"
+
+            if ! trivy image \
+              --severity "$TRIVY_SEVERITY" \
+              --exit-code 1 \
+              --format table \
+              "$image" | tee "trivy-reports/${report_name}.txt"; then
+              scan_status=1
+            fi
+
+            trivy image \
+              --severity "$TRIVY_REPORT_SEVERITY" \
+              --exit-code 0 \
+              --format json \
+              --output "trivy-reports/${report_name}.json" \
+              "$image"
+
+            echo "::endgroup::"
+          done < image-list.txt
+
+          exit "$scan_status"
+
+      - name: Upload Trivy reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-image-reports
+          path: |
+            image-list.txt
+            trivy-reports/
+          if-no-files-found: warn

--- a/scripts/list_manifest_images.py
+++ b/scripts/list_manifest_images.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import argparse
+import pathlib
+import re
+import sys
+
+
+IMAGE_PATTERN = re.compile(r"^\s*image:\s*(['\"]?)(?P<image>[^'\"\s#]+)\1(?:\s+#.*)?$")
+YAML_SUFFIXES = {".yaml", ".yml"}
+
+
+def iter_yaml_files(paths):
+    for raw_path in paths:
+        path = pathlib.Path(raw_path)
+        if path.is_file() and path.suffix in YAML_SUFFIXES:
+            yield path
+        elif path.is_dir():
+            yield from sorted(
+                candidate
+                for candidate in path.rglob("*")
+                if candidate.is_file() and candidate.suffix in YAML_SUFFIXES
+            )
+
+
+def collect_images(paths):
+    images = set()
+    for manifest_path in iter_yaml_files(paths):
+        for line in manifest_path.read_text(encoding="utf-8").splitlines():
+            match = IMAGE_PATTERN.match(line)
+            if match:
+                images.add(match.group("image"))
+    return sorted(images)
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description="List container images referenced by Kubernetes YAML manifests.")
+    parser.add_argument("paths", nargs="+", help="Manifest files or directories to scan.")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv or sys.argv[1:])
+    for image in collect_images(args.paths):
+        print(image)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_list_manifest_images.py
+++ b/tests/test_list_manifest_images.py
@@ -1,0 +1,82 @@
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "list_manifest_images.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("list_manifest_images", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ListManifestImagesTests(unittest.TestCase):
+    def test_collects_unique_images_from_yaml_manifests(self):
+        module = load_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            (root / "deployment.yaml").write_text(
+                """
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27.5
+        - name: api
+          image: "ealen/echo-server"
+""",
+                encoding="utf-8",
+            )
+            nested = root / "nested"
+            nested.mkdir()
+            (nested / "statefulset.yml").write_text(
+                """
+apiVersion: apps/v1
+kind: StatefulSet
+spec:
+  template:
+    spec:
+      containers:
+        - name: db
+          image: 'redis:7'
+        - name: duplicate
+          image: nginx:1.27.5
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                module.collect_images([root]),
+                ["ealen/echo-server", "nginx:1.27.5", "redis:7"],
+            )
+
+    def test_ignores_comments_and_non_yaml_files(self):
+        module = load_module()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            (root / "notes.txt").write_text("image: ignored:latest\n", encoding="utf-8")
+            (root / "pod.yaml").write_text(
+                """
+# image: comment:latest
+containers:
+  - name: app
+    image: busybox:1.36 # inline comment
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(module.collect_images([root]), ["busybox:1.36"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈
- Closes #35 

## 무엇을 만들었나요? (What)
- manifest에 정의된 컨테이너 이미지를 CI에서 취약점 스캔하는 GitHub Actions workflow 추가
- scripts/list_manifest_images.py를 추가해 manifests/** 아래 YAML 파일의 image 값을 중복 없이 추출
- Trivy를 사용해 추출된 이미지의 취약점을 검사하고, 발견 시 CI job이 실패하도록 구성
- 스캔 결과를 `trivy-reports` artifact로 업로드

## 왜 이렇게 만들었나요? (Why)
- 현재 ECR 기반 이미지 스캔을 사용하지 않으므로, 배포 전 단계에서 취약 이미지를 차단하려면 CI/CD에 직접 이미지 스캔을 추가하는 방식이 가장 적합하다.
- 컨테이너 이미지는 OS 패키지, 언어 런타임, 애플리케이션 의존성을 함께 포함하므로, 하나의 알려진 CVE가 해당 이미지를 사용하는 모든 Pod에 영향을 줄 수 있다.
- 매니페스트의 이미지 목록을 자동 추출하도록 만들어 이미지가 추가되거나 변경될 때 workflow를 수동으로 수정하지 않아도 되게 했다.
- Trivy 공급망 보안 권고를 반영해 `setup-trivy@v0.2.6`, Trivy binary `v0.69.3`으로 버전을 고정했다.

## 테스트
`python -m unittest tests.test_list_manifest_images -v`로 단위 테스트를 성공하는 것은 확인했으나, 실제 실행을 확인하기 위해서는 Github Actions에서 workflow 실행을 확인해야 한다.

## 참고
- 현재 스캔 대상 이미지는 `ealen/echo-server`, `nginx:1.27.5`, `redis:7`이다.
- artifact 무료 저장 공간 수준을 넘어갈 시 CI가 실패할 수 있다.
