### PR TITLE
[Feat] Cluster resource 사용 제한 (team a)

### DIFF
--- a/modules/namespaces/main.tf
+++ b/modules/namespaces/main.tf
@@ -9,3 +9,36 @@ resource "kubernetes_namespace_v1" "teams" {
     }
   }
 }
+
+variable "default_namespace_resource_quota_hard" {
+  description = "Default hard resource quota applied to the limited namespace."
+  type        = map(string)
+
+  default = {
+    pods              = "20"
+    "requests.cpu"    = "2"
+    "requests.memory" = "4Gi"
+    "limits.cpu"      = "4"
+    "limits.memory"   = "8Gi"
+  }
+}
+
+variable "namespace_container_default_requests" {
+  description = "Default container resource requests applied by LimitRange."
+  type        = map(string)
+
+  default = {
+    cpu    = "100m"
+    memory = "128Mi"
+  }
+}
+
+variable "namespace_container_default_limits" {
+  description = "Default container resource limits applied by LimitRange."
+  type        = map(string)
+
+  default = {
+    cpu    = "500m"
+    memory = "512Mi"
+  }
+}

--- a/modules/namespaces/main.tf
+++ b/modules/namespaces/main.tf
@@ -10,35 +10,50 @@ resource "kubernetes_namespace_v1" "teams" {
   }
 }
 
-variable "default_namespace_resource_quota_hard" {
-  description = "Default hard resource quota applied to the limited namespace."
-  type        = map(string)
-
-  default = {
-    pods              = "20"
-    "requests.cpu"    = "2"
-    "requests.memory" = "4Gi"
-    "limits.cpu"      = "4"
-    "limits.memory"   = "8Gi"
+locals {
+  resource_limited_namespaces = {
+    for name, namespace in kubernetes_namespace_v1.teams :
+    name => namespace
+    if name == "team-a"
   }
 }
 
-variable "namespace_container_default_requests" {
-  description = "Default container resource requests applied by LimitRange."
-  type        = map(string)
+resource "kubernetes_resource_quota_v1" "teams" {
+  for_each = local.resource_limited_namespaces
 
-  default = {
-    cpu    = "100m"
-    memory = "128Mi"
+  metadata {
+    name      = "team-resource-quota"
+    namespace = each.value.metadata[0].name
+
+    labels = {
+      "app.kubernetes.io/part-of" = var.project_name
+      "training.k8rvis.io/team"   = each.key
+    }
+  }
+
+  spec {
+    hard = var.default_namespace_resource_quota_hard
   }
 }
 
-variable "namespace_container_default_limits" {
-  description = "Default container resource limits applied by LimitRange."
-  type        = map(string)
+resource "kubernetes_limit_range_v1" "teams" {
+  for_each = local.resource_limited_namespaces
 
-  default = {
-    cpu    = "500m"
-    memory = "512Mi"
+  metadata {
+    name      = "team-container-limits"
+    namespace = each.value.metadata[0].name
+
+    labels = {
+      "app.kubernetes.io/part-of" = var.project_name
+      "training.k8rvis.io/team"   = each.key
+    }
+  }
+
+  spec {
+    limit {
+      type            = "Container"
+      default         = var.namespace_container_default_limits
+      default_request = var.namespace_container_default_requests
+    }
   }
 }

--- a/modules/namespaces/variables.tf
+++ b/modules/namespaces/variables.tf
@@ -8,3 +8,36 @@ variable "team_names" {
   type        = list(string)
   default     = ["team-a", "team-b", "team-c", "team-d"]
 }
+
+variable "default_namespace_resource_quota_hard" {
+  description = "Default hard resource quota applied to each team namespace."
+  type        = map(string)
+
+  default = {
+    pods              = "20"
+    "requests.cpu"    = "2"
+    "requests.memory" = "4Gi"
+    "limits.cpu"      = "4"
+    "limits.memory"   = "8Gi"
+  }
+}
+
+variable "namespace_container_default_requests" {
+  description = "Default container resource requests applied by LimitRange."
+  type        = map(string)
+
+  default = {
+    cpu    = "100m"
+    memory = "128Mi"
+  }
+}
+
+variable "namespace_container_default_limits" {
+  description = "Default container resource limits applied by LimitRange."
+  type        = map(string)
+
+  default = {
+    cpu    = "500m"
+    memory = "512Mi"
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #12

## 무엇을 만들었나요? (What)
- modules/namespaces에 ResourceQuota와 LimitRange 리소스를 추가했다.
- team-a namespace에만 CPU/Memory 및 Pod 개수 사용량 제한이 적용되도록 구성했다.
> pods: 20
> requests.cpu: 2
> requests.memory: 4Gi
> limits.cpu: 4
> limits.memory: 8Gi

이 값은 임의로 설정한 값으로 추후 상황에 맞게 변경 가능하다. 

## 왜 이렇게 만들었나요? (Why)
- 특정 namespace의 리소스 사용량이 과도하게 증가해 클러스터 전체 안정성에 영향을 주는 상황을 방지하기 위해 적용하였다. 
- ResourceQuota만 적용할 경우, request/limit이 없는 Pod 생성 시 문제가 발생할 수 있기에 LimitRange를 함께 적용하였다.
- LimitRange를 통해 리소스 설정이 없는 워크로드에도 기본 CPU/Memory 기준(코드에서 default값으로 설정)이 적용되도록 하였다.
- 실습 및 검증 범위를 명확히 하기 위해 전체 팀 namespace가 아닌 team-a에만 제한 정책을 적용하였으며, 필요 시 동일한 구조를 확장하여 team-b, team-c, team-d에도 동일 정책을 적용할 수 있다.

## 테스트
### 1. 패치 전 리소스 제한 상태를 확인
<img width="361" height="37" alt="스크린샷 2026-04-28 161018" src="https://github.com/user-attachments/assets/f60913b4-4639-4ca2-afa5-1272e3f22411" />
현재 상태를 확인해보면 다음과 같이 설정된 것이 없는 것을 알 수 있다. 

### 2. 패치 후
<img width="970" height="104" alt="스크린샷 2026-04-28 162005" src="https://github.com/user-attachments/assets/84851b37-1c36-4a7f-a9e7-574e7b56685a" />
다음과 같이 패치가 적용되어 ResourceQuota, LimitRange 리소스가 생성된 것을 확인할 수 있다. 

<img width="748" height="138" alt="스크린샷 2026-04-28 162133" src="https://github.com/user-attachments/assets/a31c2989-d033-4c6c-8da2-3cc64cc26b93" />
namespace 별로 적용 가능하므로 다음과 같이 team-a에 대해서만 적용된 것을 확인할 수 있다. 

<img width="1094" height="203" alt="스크린샷 2026-04-28 162726" src="https://github.com/user-attachments/assets/4861f527-bb1b-470e-bd96-83a6f3cbe737" />
새롭게 워크로드를 배포한 후 생성한 리소스가 동작하는 것을 확인할 수 있다. 

<img width="1421" height="274" alt="스크린샷 2026-04-28 163328" src="https://github.com/user-attachments/assets/f4c644f2-ef7e-4fe0-bf84-1752928a1757" />

`kubectl scale deployment web -n team-a --replicas=25`
위의 명령어를 사용하여 replicas 수를 늘리면 다음과 같이 일부 Pod은 ResourceQuota와 LimitRange 로 인해 생성되지 않은 것을 확인할 수 있다.

## 참고
특정 namespace가 아닌 모든 namespace에 적용가능하도록 하려면 수정한 main.tf 와 variables.tf 파일에서 적용되는 범위를 locals 가 아닌 teams로 변경하면 된다. (추가로 local안의 name을 수정하여 다른 namespace에 대해 적용할 수도 있다.
