### PR TITLE
[Feat] containter image 스캔 및 취약점 확인 (team-a)

### DIFF
--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        trivyignores: .trivyignore
 
       - name: Generate JSON report
         uses: aquasecurity/trivy-action@v0.36.0
@@ -52,6 +53,7 @@ jobs:
           vuln-type: os,library
           severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
           version: v0.70.0
+          trivyignores: .trivyignore
 
       - name: Generate SARIF report
         uses: aquasecurity/trivy-action@v0.36.0
@@ -67,6 +69,7 @@ jobs:
           limit-severities-for-sarif: true
           version: v0.70.0
           skip-setup-trivy: true
+          trivyignores: .trivyignore
 
       - name: Upload Trivy reports
         if: always()
@@ -77,6 +80,7 @@ jobs:
             trivy-${{ matrix.name }}.json
             trivy-${{ matrix.name }}.sarif
           retention-days: 30
+          trivyignores: .trivyignore
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always()
@@ -85,6 +89,7 @@ jobs:
         with:
           sarif_file: trivy-${{ matrix.name }}.sarif
           category: trivy-${{ matrix.name }}
+          trivyignores: .trivyignore
 
       - name: Fail on HIGH or CRITICAL vulnerabilities
         uses: aquasecurity/trivy-action@v0.36.0
@@ -98,3 +103,4 @@ jobs:
           severity: CRITICAL,HIGH
           version: v0.70.0
           skip-setup-trivy: true
+          trivyignores: .trivyignore

--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -1,0 +1,100 @@
+name: Container Image Vulnerability Scan
+
+on:
+  pull_request:
+    paths:
+      - "manifests/**"
+      - ".github/workflows/container-image-scan.yml"
+      - ".trivyignore"
+  push:
+    branches:
+      - main
+    paths:
+      - "manifests/**"
+      - ".github/workflows/container-image-scan.yml"
+      - ".trivyignore"
+  schedule:
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  trivy-image-scan:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: api
+            image: ealen/echo-server
+          - name: web
+            image: nginx:1.27.5
+          - name: db
+            image: redis:7
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Generate JSON report
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ matrix.image }}
+          format: json
+          output: trivy-${{ matrix.name }}.json
+          exit-code: "0"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          version: v0.70.0
+
+      - name: Generate SARIF report
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ matrix.image }}
+          format: sarif
+          output: trivy-${{ matrix.name }}.sarif
+          exit-code: "0"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
+          version: v0.70.0
+          skip-setup-trivy: true
+
+      - name: Upload Trivy reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-${{ matrix.name }}-reports
+          path: |
+            trivy-${{ matrix.name }}.json
+            trivy-${{ matrix.name }}.sarif
+          retention-days: 30
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-${{ matrix.name }}.sarif
+          category: trivy-${{ matrix.name }}
+
+      - name: Fail on HIGH or CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ matrix.image }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          version: v0.70.0
+          skip-setup-trivy: true

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# reason: false positive, reviewed by security-team
+# image: nginx:1.27.5
+CVE-2026-12345 exp:2025-04-31  # 예시로 추가한 내용이며 exp를 통해 해당 CVE 예외처리 유효기한을 설정한다. 


### PR DESCRIPTION
## 관련 이슈
- Closes #35

## 무엇을 만들었나요? (What)
- 컨테이너 이미지 취약점 탐지를 위한 GitHub Actions 워크플로우를 추가하였다.
: `.github/workflows/container-image-scan.yml`
- manifest에서 사용하는 이미지 3개를 Trivy로 스캔하도록 구성하였다.
> `ealen/echo-server`
> `nginx:1.27.5`
> `redis:7`
- Trivy 스캔 결과를 JSON/SARIF 리포트로 생성하고 GitHub Actions artifact로 보관하도록 하였다.
- HIGH/ CRITICAL 취약점이 발견되면 workflow가 실패하도록 하였으며 Trivy Action과 Trivy CLI 버전을 고정하였다.
> `aquasecurity/trivy-action@v0.36.0`
 > `Trivy v0.70.0`

## 왜 이렇게 만들었나요? (Why)
- 취약한 컨테이너 이미지가 EKS 환경에 배포되기 전에 CI 단계에서 차단하기 위해 패치를 진행하였다.
- `pull_request`에서 스캔을 실행하여 merge하기 전, 문제를 확인하고 main `push`와 `schedule` 실행을 통해 이후 새로 공개되는 CVE에 대하여 재탐지할 수 있도록 하였다. 
- 스캔 실패 전에 JSON/SARIF 리포트를 먼저 생성하고 artifact로 저장하도록 하여 workflow가 실패해도 어떤 이미지와 CVE 때문에 실패했는지 확인할 수 있으며 `fail-fast: false` matrix 전략을 사용하여 한 이미지에서 취약점이 발견되어도 나머지 이미지 스캔 결과까지 모두 확인할 수 있도록 하였다. 

## 참고
- 현재 저장소에는 ECR repository 리소스가 없기에 ECR scan-on-push는 이번 PR 범위에 포함하지 않았다. 
- 필요한 경우 false positive 또는 패치 미제공 취약점을 관리할 수 있도록 `.trivyignore` 를 통해 예외 처리를 적용할 수 있으며 예시를 통해 false positive 또는 패치 미제공 취약점에 대해 `.trivyignore`에 CVE ID와 만료일(`exp:YYYY-MM-DD`)을 명시하여 관리가 가능하다. 
- Trivy 버전을 고정함으로써 CI 결과의 재현성을 높이고, 공급망 리스크를 줄이고자 하였다.

