### PR TITLE
[Feat] ingress와 LB에 TLS (team c)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+*.tfvars

--- a/environments/infra/.terraform.lock.hcl
+++ b/environments/infra/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",

--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -25,4 +25,22 @@ module "eks" {
   node_ami_type      = var.node_ami_type
   node_group         = var.node_group
   default_tags       = var.default_tags
+
+
+authentication_mode = "API_AND_CONFIG_MAP"
+  access_entries = {
+    teamc_user = {
+      principal_arn = var.user_iam_arn
+      policy_associations = {
+        admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+
 }
+

--- a/environments/infra/terraform.tfvars
+++ b/environments/infra/terraform.tfvars
@@ -38,3 +38,5 @@ node_group = {
   max_size       = 3
   disk_size_gb   = 20
 }
+
+user_iam_arn= "arn:aws:iam::357542025037:role/aws-reserved/sso.amazonaws.com/ap-northeast-2/AWSReservedSSO_AdministratorAccess_3a39e04d118e4347"

--- a/environments/infra/variables.tf
+++ b/environments/infra/variables.tf
@@ -80,3 +80,7 @@ variable "node_group" {
     disk_size_gb   = 20
   }
 }
+variable "user_iam_arn" {
+  description = "EKS 관리자 권한을 부여할 IAM ARN"
+  type        = string
+}

--- a/environments/platform/.terraform.lock.hcl
+++ b/environments/platform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "~> 2.0"
   hashes = [
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "h1:rsqAO9oKyDMLiysQqrWEzf9CNtU9NJtwEGk7bSItC9g=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
     "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:1OF0rDUteVdoX04BrtmTc0T4NOo6+D0utmK6hM0EzZw=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
@@ -61,5 +64,24 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
     "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
     "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.2.1"
+  hashes = [
+    "h1:4RrYf1s+LL8tozFP2uqJDAakrVqJF4sqZTM5EPQ+Nhg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -11,6 +11,24 @@ data "terraform_remote_state" "infra" {
 data "aws_eks_cluster_auth" "infra" {
   name = data.terraform_remote_state.infra.outputs.cluster_name
 }
+variable "cluster_name" {
+  default = "eks-secure-infra-dev"
+}
+
+data "aws_eks_cluster" "this" {
+  name = var.cluster_name
+}
+ 
+data "tls_certificate" "eks" {
+  url = data.aws_eks_cluster.this.identity[0].oidc[0].issuer
+}
+
+# 2. OIDC Provider를 직접 생성(Resource)합니다. (Data가 아니라 Resource입니다!)
+resource "aws_iam_openid_connect_provider" "this" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.eks.certificates[0].sha1_fingerprint]
+  url             = data.aws_eks_cluster.this.identity[0].oidc[0].issuer
+}
 
 module "k8s_base" {
   source = "../../modules/k8s-base"
@@ -23,6 +41,9 @@ module "k8s_base" {
   aws_node_termination_handler_chart_version = var.aws_node_termination_handler_chart_version
   ingress_nginx_namespace                    = var.ingress_nginx_namespace
   ingress_nginx_chart_version                = var.ingress_nginx_chart_version
+  cluster_name      = var.cluster_name
+  oidc_provider_url = aws_iam_openid_connect_provider.this.url
+  oidc_provider_arn = aws_iam_openid_connect_provider.this.arn
 }
 
 module "namespaces" {

--- a/manifests/overlays/team-c/kustomization.yaml
+++ b/manifests/overlays/team-c/kustomization.yaml
@@ -11,3 +11,4 @@ patches:
     target:
       kind: Ingress
       name: web
+  - path: service-patch.yaml

--- a/manifests/overlays/team-c/kustomization.yaml
+++ b/manifests/overlays/team-c/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: team-c
 
 resources:
   - ../../base
+  - webhook-patch.yaml
 
 patches:
   - path: web-ingress-patch.yaml
@@ -12,3 +13,6 @@ patches:
       kind: Ingress
       name: web
   - path: service-patch.yaml
+    target:
+      kind: Service
+      name: web

--- a/manifests/overlays/team-c/service-patch.yaml
+++ b/manifests/overlays/team-c/service-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: team-c
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: web # Deployment의 label과 일치
+  ports:
+    - protocol: TCP
+      port: 80 # Ingress가 바라보는 포트
+      targetPort: 80 # Deployment 컨테이너가 열어놓은 포트

--- a/manifests/overlays/team-c/service-patch.yaml
+++ b/manifests/overlays/team-c/service-patch.yaml
@@ -4,10 +4,10 @@ metadata:
   name: web
   namespace: team-c
 spec:
-  type: NodePort
+  type: NodePort #clusterIP에서 변경
   selector:
-    app.kubernetes.io/name: web # Deployment의 label과 일치
+    app.kubernetes.io/name: web
   ports:
-    - protocol: TCP
-      port: 80 # Ingress가 바라보는 포트
-      targetPort: 80 # Deployment 컨테이너가 열어놓은 포트
+    - protocol: TCP #작성하지 않아도 default로 적용됨
+      port: 80
+      targetPort: 80

--- a/manifests/overlays/team-c/web-ingress-patch.yaml
+++ b/manifests/overlays/team-c/web-ingress-patch.yaml
@@ -1,11 +1,27 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: web
+  name: ingress
+  namespace: team-c
+  annotations:
+    #  ALB 컨트롤러 사용 선언
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+
+    #  ACM 인증서 연결
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-2:357542025037:certificate/6e95b8cb-8e7a-44ac-a47d-be12cf7a413b
+
+    # 포트 설정
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+
+    #  HTTPS 강제
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+
+    # 보안 정책 (최신 TLS 버전만 허용)
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
 spec:
   rules:
-    - host: team-c.training.local
-      http:
+    - http:
         paths:
           - path: /
             pathType: Prefix

--- a/manifests/overlays/team-c/web-ingress-patch.yaml
+++ b/manifests/overlays/team-c/web-ingress-patch.yaml
@@ -1,27 +1,25 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress
+  name: web
   namespace: team-c
   annotations:
     #  ALB 컨트롤러 사용 선언
-    kubernetes.io/ingress.class: alb
+    # kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
-
     #  ACM 인증서 연결
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-2:357542025037:certificate/6e95b8cb-8e7a-44ac-a47d-be12cf7a413b
-
     # 포트 설정
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-
     #  HTTPS 강제
     alb.ingress.kubernetes.io/ssl-redirect: "443"
-
-    # 보안 정책 (최신 TLS 버전만 허용)
+    # 보안 정책 (최신 TLS 버전)
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
 spec:
+  ingressClassName: alb
   rules:
-    - http:
+    - host: team-c.terraform-study-esc.shop
+      http:
         paths:
           - path: /
             pathType: Prefix

--- a/manifests/overlays/team-c/webhook-patch.yaml
+++ b/manifests/overlays/team-c/webhook-patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: ingress-nginx-admission
+webhooks:
+  - name: validate.nginx.ingress.kubernetes.io
+    rules:
+      - apiGroups: ["networking.k8s.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["ingresses"]
+    failurePolicy: Ignore
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: ingress-nginx-controller-admission
+        namespace: ingress-nginx
+        path: "/networking/v1/ingresses"

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -102,8 +102,13 @@ resource "aws_eks_cluster" "this" {
 
   vpc_config {
     subnet_ids              = var.cluster_subnet_ids
-    endpoint_private_access = true
     endpoint_public_access  = true
+  }
+
+    # API 기반 인증 활성화 
+  access_config {
+    authentication_mode = var.authentication_mode
+    bootstrap_cluster_creator_admin_permissions = true 
   }
 
   depends_on = [
@@ -204,4 +209,44 @@ resource "aws_eks_node_group" "this" {
       Name = local.node_group_name
     }
   )
+  
+}
+# 클러스터에 등록
+resource "aws_eks_access_entry" "this" {
+  for_each = var.access_entries
+
+  cluster_name      = aws_eks_cluster.this.name
+  principal_arn     = each.value.principal_arn
+  type              = "STANDARD"
+}
+
+# 2. 등록된 신분에 실제 권한 정책 연결
+resource "aws_eks_access_policy_association" "this" {
+  # 변수 내의 policy_associations를 모두 찾아서 연결하는 반복문
+  for_each = {
+    for pair in flatten([
+      for name, entry in var.access_entries : [
+        for policy_name, policy in entry.policy_associations : {
+          entry_name  = name
+          policy_name = policy_name
+          principal   = entry.principal_arn
+          policy_arn  = policy.policy_arn
+          scope       = policy.access_scope
+        }
+      ]
+    ]) : "${pair.entry_name}-${pair.policy_name}" => pair
+  }
+
+  cluster_name  = aws_eks_cluster.this.name
+  policy_arn    = each.value.policy_arn
+  principal_arn = each.value.principal
+
+  access_scope {
+    type       = each.value.scope.type
+    namespaces = lookup(each.value.scope, "namespaces", null)
+  }
+
+  depends_on = [
+    aws_eks_access_entry.this
+  ]
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -79,3 +79,14 @@ variable "default_tags" {
   type        = map(string)
   default     = {}
 }
+variable "access_entries" {
+  description = "EKS cluster에 접속할 IAM user 및 권한 mapping"
+  type        = any
+  default     = {}
+}
+
+variable "authentication_mode" {
+  description = "EKS 클러스터 인증 모드"
+  type        = string
+  default     = "API_AND_CONFIG_MAP"
+}

--- a/modules/k8s-base/iam.tf
+++ b/modules/k8s-base/iam.tf
@@ -1,0 +1,37 @@
+# 1. IAM 정책 
+resource "aws_iam_policy" "lbc_policy" {
+  name        = "${var.cluster_name}-lbc-policy"
+  path        = "/"
+  description = "AWS Load Balancer Controller Policy"
+  # 실제 정책 내용은 외부 json 파일을 읽어오거나 직접 입력합니다.
+  policy      = file("${path.module}/iam_policy.json") 
+}
+
+# 2. IAM 역할 및 신뢰 관계
+resource "aws_iam_role" "lbc_role" {
+  name = "${var.cluster_name}-lbc-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = var.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(var.oidc_provider_url, "https://", "")}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# 3. 역할에 정책 연결
+resource "aws_iam_role_policy_attachment" "lbc_attach" {
+  role       = aws_iam_role.lbc_role.name
+  policy_arn = aws_iam_policy.lbc_policy.arn
+}

--- a/modules/k8s-base/iam_policy.json
+++ b/modules/k8s-base/iam_policy.json
@@ -1,0 +1,232 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["iam:CreateServiceLinkedRole"],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeVpcPeeringConnections",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeInstances",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeTags",
+        "ec2:GetCoipPoolUsage",
+        "ec2:DescribeCoipPools",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeListenerAttributes",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeTrustStores"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient",
+        "acm:ListCertificates",
+        "acm:DescribeCertificate",
+        "iam:ListServerCertificates",
+        "iam:GetServerCertificate",
+        "waf-regional:GetWebACL",
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL",
+        "waf-v2:GetWebACL",
+        "waf-v2:GetWebACLForResource",
+        "waf-v2:AssociateWebACL",
+        "waf-v2:DisassociateWebACL",
+        "shield:GetSubscriptionState",
+        "shield:DescribeProtection",
+        "shield:CreateProtection",
+        "shield:DeleteProtection"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:CreateSecurityGroup"],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:CreateTags"],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "CreateSecurityGroup"
+        },
+        "Null": {
+          "ec2:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:CreateTags", "ec2:DeleteTags"],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "Null": {
+          "ec2:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:DeleteSecurityGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:DeleteRule"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener/obj/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/obj/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:listener/obj/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/obj/*/*/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:DeleteTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["elasticloadbalancing:AddTags"],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "elasticloadbalancing:CreateAction": [
+            "CreateTargetGroup",
+            "CreateLoadBalancer"
+          ]
+        },
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:DeregisterTargets"
+      ],
+      "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:SetWebAcl",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:ModifyRule"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -65,3 +65,24 @@ resource "helm_release" "ingress_nginx" {
     EOT
   ]
 }
+resource "helm_release" "lbc" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  namespace  = "kube-system"
+  
+
+  values = [
+    yamlencode({
+      clusterName = var.cluster_name
+      serviceAccount = {
+        create = true
+        name   = "aws-load-balancer-controller"
+        annotations = {
+          "eks.amazonaws.com/role-arn" = aws_iam_role.lbc_role.arn
+        }
+      }
+      region = "ap-northeast-2"
+    })
+  ]
+}

--- a/modules/k8s-base/variables.tf
+++ b/modules/k8s-base/variables.tf
@@ -45,3 +45,17 @@ variable "ingress_nginx_chart_version" {
   type        = string
   default     = "4.14.1"
 }
+variable "cluster_name" {
+  description = "EKS 클러스터 이름"
+  type        = string
+}
+
+variable "oidc_provider_url" {
+  description = "EKS 클러스터의 OIDC Provider URL"
+  type        = string
+}
+
+variable "oidc_provider_arn" {
+  description = "EKS 클러스터의 OIDC Provider ARN"
+  type        = string
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #9 

## 무엇을 만들었나요? (What)
- EKS 보안 인증 기반(OIDC Provider) 구축
- AWS Load Balancer Controller 및 IRSA 환경 구성
1. IRSA(IAM Roles for Service Accounts)를 적용하여 '최소 권한 원칙'에 따른 컨트롤러 전용 IAM Role과 Policy 설계
2. Helm을 통해 클러스터 내에서 AWS 리소스를 직접 제어하고 관리할 수 있는 컨트롤러 배포
- HTTPS 강제 게이트웨이(ALB Ingress) 전환
기존 Nginx 기반 ingress를 AWS Application Load Balancer(ALB)로 전환하도록 변경
- Admission Webhook 최적화
인프라 구성 요소 간의 충돌로 인한 배포 중단을 방지하기 위해, 유효성 검사 웹훅의 실패 정책(failurePolicy)을 수정한 Kustomize 패치 적용

## 왜 이렇게 만들었나요? (Why)
- IRSA 방식을 선택한 이유는 worker node 전체에 권한을 부여하기보단, 특정 pod(controller)에게만 필요한 권한을 부여하기 위해서이다.
- 모든 트래픽을 TLS로 암호화하여 데이터 탈취 위험을 차단하기 위함이다.

## 실습 과정(수정 필요)
- 필요한 부분에 대한 patch파일은 모두 적용했지만 address가 할당되지 않은 것으로 보아 IRSA 또는 설정값에 문제가 있는 것으로 보인다. 
<img width="735" height="102" alt="스크린샷 2026-04-28 202300" src="https://github.com/user-attachments/assets/df9c6a89-1138-4313-bb09-0f687f48e271" />

AWS Load Balancer Controller가 실제 ALB 리소스를 생성하려 시도했으나 권한 부족(403 Access Denied) 오류가 발생하고 있어, 해당 문제를 해결해보고 있다.