### PR TITLE
[Feature] 데이터 보호: 외부 진입점 TLS 인증서 자동 관리(team-b)

### DIFF
--- a/environments/infra/.terraform.lock.hcl
+++ b/environments/infra/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 5.0"
   hashes = [
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",

--- a/environments/platform/.terraform.lock.hcl
+++ b/environments/platform/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
-    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
@@ -28,7 +28,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
   constraints = "~> 2.0"
   hashes = [
-    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
     "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
@@ -48,7 +48,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.0"
   hashes = [
-    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
     "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",

--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -23,6 +23,8 @@ module "k8s_base" {
   aws_node_termination_handler_chart_version = var.aws_node_termination_handler_chart_version
   ingress_nginx_namespace                    = var.ingress_nginx_namespace
   ingress_nginx_chart_version                = var.ingress_nginx_chart_version
+  acm_certificate_arn                        = var.acm_certificate_arn
+  ssl_policy                                 = var.ssl_policy
 }
 
 module "namespaces" {

--- a/environments/platform/providers.tf
+++ b/environments/platform/providers.tf
@@ -23,16 +23,20 @@ provider "aws" {
   region = var.aws_region
 }
 
+data "aws_eks_cluster" "infra" {
+  name = data.terraform_remote_state.infra.outputs.cluster_name
+}
+
 provider "kubernetes" {
-  host                   = data.terraform_remote_state.infra.outputs.cluster_endpoint
-  cluster_ca_certificate = base64decode(data.terraform_remote_state.infra.outputs.cluster_certificate_authority_data)
+  host                   = data.aws_eks_cluster.infra.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.infra.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.infra.token
 }
 
 provider "helm" {
   kubernetes {
-    host                   = data.terraform_remote_state.infra.outputs.cluster_endpoint
-    cluster_ca_certificate = base64decode(data.terraform_remote_state.infra.outputs.cluster_certificate_authority_data)
+    host                   = data.aws_eks_cluster.infra.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.infra.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.infra.token
   }
 }

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -124,3 +124,15 @@ variable "team_names" {
   type        = list(string)
   default     = ["team-a", "team-b", "team-c", "team-d"]
 }
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN attached to the NLB HTTPS listener. Empty string disables TLS at the NLB."
+  type        = string
+  default     = ""
+}
+
+variable "ssl_policy" {
+  description = "TLS security policy applied to the NLB HTTPS listener."
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}

--- a/manifests/overlays/team-b/web-ingress-patch.yaml
+++ b/manifests/overlays/team-b/web-ingress-patch.yaml
@@ -2,9 +2,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   rules:
-    - host: team-b.training.local
+    - host: k8rvis-teamb.p-e.kr
       http:
         paths:
           - path: /

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -54,14 +54,24 @@ resource "helm_release" "ingress_nginx" {
   wait             = true
 
   values = [
-    <<-EOT
-    controller:
-      ingressClassResource:
-        default: true
-      service:
-        type: LoadBalancer
-        annotations:
-          service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-    EOT
+    yamlencode({
+      controller = {
+        ingressClassResource = { default = true }
+        config = {
+          use-forwarded-headers      = "true"
+          compute-full-forwarded-for = "true"
+        }
+        service = {
+          type = "LoadBalancer"
+          annotations = {
+            "service.beta.kubernetes.io/aws-load-balancer-scheme"                  = "internet-facing"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-cert"                = var.acm_certificate_arn
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-ports"               = "443"
+            "service.beta.kubernetes.io/aws-load-balancer-backend-protocol"        = "tcp"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy"  = var.ssl_policy
+          }
+        }
+      }
+    })
   ]
 }

--- a/modules/k8s-base/variables.tf
+++ b/modules/k8s-base/variables.tf
@@ -1,7 +1,7 @@
 variable "helm_release_timeout_seconds" {
   description = "Timeout in seconds applied to each addon helm release."
   type        = number
-  default     = 600
+  default     = 1200
 }
 
 variable "metrics_server_namespace" {
@@ -44,4 +44,16 @@ variable "ingress_nginx_chart_version" {
   description = "Pinned chart version for ingress-nginx."
   type        = string
   default     = "4.14.1"
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN attached to the NLB HTTPS listener. Empty string disables TLS at the NLB."
+  type        = string
+  default     = ""
+}
+
+variable "ssl_policy" {
+  description = "TLS security policy applied to the NLB HTTPS listener."
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #26 

## 무엇을 만들었나요? (What)
ngress-nginx NLB에 ACM 인증서를 연결하는 Terraform 변수(acm_certificate_arn, ssl_policy)를 추가하고, team-b의 Ingress에 HTTP→HTTPS 강제 리다이렉트 annotation을 설정했습니다.

## 왜 이렇게 만들었나요? (Why)
NLB에서 ACM 인증서로 TLS를 종료하면 Kubernetes 내부에 인증서를 관리할 필요 없이 AWS가 자동으로 갱신·관리하며, HTTP 트래픽이 클러스터에 도달하기 전에 HTTPS로 강제 전환되어 전송 중 데이터 암호화를 보장합니다.

## 테스트
### 1. 취약점 확인 — HTTP 평문 통신 가능 여부 점검

NLB 주소 확인

`kubectl get svc -n ingress-nginx ingress-nginx-controller`
<img width="1065" height="87" alt="image (27)" src="https://github.com/user-attachments/assets/d5d30381-ae91-42f8-81f4-b8243f598a5e" />



Host 확인

`kubectl get ingress web -n team-b -o jsonpath='{.spec.rules[*].host}’`

<img width="803" height="41" alt="image (28)" src="https://github.com/user-attachments/assets/a034452b-4af4-4924-b581-e1fd31c26234" />


HTTP로 접근 가능한지 확인 (취약한 상태)

`curl -v http://<NLB_주소>/`
<img width="996" height="348" alt="image (29)" src="https://github.com/user-attachments/assets/23a69366-fe95-410a-8182-491c9446dbec" />


→ HTTP 200 응답이 오면 평문 통신이 허용된 상태 (취약)

### 2. ACM 인증서 ARN 확인

AWS 콘솔 또는 CLI로 발급된 인증서 ARN 확인
`AWS_PROFILE=team-b aws acm list-certificates --region ap-northeast-2`

인증서 상태가 ISSUED인지 확인
`AWS_PROFILE=team-b aws acm describe-certificate \
  --certificate-arn <CERT_ARN> \
  --region ap-northeast-2 \
  --query 'Certificate.Status'`

<img width="718" height="145" alt="image (30)" src="https://github.com/user-attachments/assets/f6fbc098-b997-445a-8973-3e57bf81b225" />

### 3. Terraform으로 ACM 인증서를 NLB에 연결

`modules/k8s-base/main.tf`의 ingress-nginx Helm values에 SSL annotation 추가:

```jsx
"service.beta.kubernetes.io/aws-load-balancer-ssl-cert"               = var.acm_certificate_arn
"service.beta.kubernetes.io/aws-load-balancer-ssl-ports"              = "443"
"service.beta.kubernetes.io/aws-load-balancer-backend-protocol"       = "tcp"
"service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy" = var.ssl_policy
```

`cd environments/platform`

`AWS_PROFILE=team-b AWS_REGION=ap-northeast-2 terraform apply \
  -var="<YOUR_ARN>"`

### 4. NLB에 ACM 인증서 annotation 적용 확인

`kubectl get svc -n ingress-nginx ingress-nginx-controller -o yaml | grep ssl`

### 5. team-b Ingress에 ssl-redirect 적용 및 배포

`manifests/overlays/team-b/web-ingress-patch.yaml`에 annotation 추가

`git add manifests/overlays/team-b/web-ingress-patch.yaml`
`git commit -m "add ssl-redirect annotation to team-b ingress"`
`git push --set-upstream origin <YOUR_BRANCH>`

ArgoCD target revision을 feature 브랜치로 변경 후 sync

`kubectl -n argocd patch app team-b --type merge -p \
  '{"spec":{"source":{"targetRevision":"<YOUR_BRANCH>}}}'
kubectl -n argocd patch app team-b --type merge -p \
  '{"operation":{"sync":{"revision":"<YOUR_BRANCH>"}}}'` 

sync 완료 확인

`kubectl get app team-b -n argocd`

### 6. team-b Ingress ssl-redirect annotation 적용 확인

`kubectl get ingress web -n team-b -o yaml | grep -A5 annotations`

<img width="728" height="273" alt="image (31)" src="https://github.com/user-attachments/assets/4c53069b-1f20-4f14-b9b7-051585d952fc" />


### 7. HTTPS 적용 확인

HTTP → HTTPS 리다이렉트 확인

`curl -v https://<LINK>/`

 → TLSv1.2 or TLSv1.3 핸드셰이크 + HTTP 200

TLS 1.1 거부 확인

`curl --tls-max 1.1 https://<LINK>/`

→ handshake failure (TLS 1.2 미만 거부됨)


