### PR TITLE
[feat] container image scan (team-c)

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,91 @@
+name: container image Vulnerability Scan
+
+on:
+  pull_request:
+    branches: ["main"]
+
+# PR댓글 작성을 위한 GitHub Token 권한 설정
+permissions:
+  pull-requests: write
+  contents: read
+
+env:
+  TARGET_IMAGE: "nginx:1.21"
+
+jobs:
+  security-scan:
+    name: Trivy Security Scan & Report
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 1. Checkout code
+        uses: actions/checkout@v4
+
+      - name: 2. Pull Target Image
+        run: docker pull ${{ env.TARGET_IMAGE }}
+
+      # CRITICAL, HIGH 발견 시 즉시 파이프라인 배포 차단
+      - name: 3. Run Trivy Scan (Block on CRITICAL, HIGH)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.TARGET_IMAGE }}
+          format: "table"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
+          exit-code: "1" # 여기서 실패하면 아래 단계는 모두 취소됨
+
+      # LOW, MEDIUM 발견 시 텍스트 파일로 결과 저장 (파이프라인 통과)
+      - name: 4. Run Trivy Scan (Report on LOW, MEDIUM)
+        if: success() # Gate 1을 무사히 통과했을 때만 실행됨
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.TARGET_IMAGE }}
+          format: "table"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "UNKNOWN,LOW,MEDIUM"
+          exit-code: "0" # 취약점이 있어도 실패 처리하지 않음
+          output: "trivy-report.txt"
+
+      # 저장된 텍스트 파일을 읽어 PR 댓글로 자동 작성
+      - name: 5. Post Trivy Report as PR Comment
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            let report = '';
+
+            // 저장된 리포트 파일 읽기
+            try {
+              report = fs.readFileSync('trivy-report.txt', 'utf8');
+            } catch (err) {
+              report = '발견된 LOW/MEDIUM 취약점이 없습니다. 완벽합니다! 🎉';
+            }
+
+            // PR 댓글 마크다운 템플릿
+            const output = `
+            ### 🛡️ Trivy Security Scan Report (LOW/MEDIUM)
+            **CRITICAL 및 HIGH 취약점 스캔을 무사히 통과했습니다!** ✅
+
+            아래는 참고용 LOW 및 MEDIUM 등급 취약점 목록입니다. 당장 배포를 막지는 않지만, 다음 스프린트 때 패치를 고려해 주세요.
+
+            <details>
+              <summary>세부 리포트 보기 (클릭하여 펼치기)</summary>
+
+              \`\`\`text
+              ${report}
+              \`\`\`
+
+            </details>
+            `;
+
+            // GitHub API를 호출하여 현재 PR에 댓글 달기
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+*.tfvars

--- a/environments/platform/.terraform.lock.hcl
+++ b/environments/platform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "~> 2.0"
   hashes = [
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "h1:rsqAO9oKyDMLiysQqrWEzf9CNtU9NJtwEGk7bSItC9g=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
     "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:1OF0rDUteVdoX04BrtmTc0T4NOo6+D0utmK6hM0EzZw=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",

--- a/modules/k8s-base/.terraform.lock.hcl
+++ b/modules/k8s-base/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version = "3.1.1"
   hashes = [
     "h1:47CqNwkxctJtL/N/JuEj+8QMg8mRNI/NWeKO5/ydfZU=",
+    "h1:s68EnUScdj1dXoXrNBaH/AIk18R2ryKeHY5H0ETfUws=",
     "zh:1a6d5ce931708aec29d1f3d9e360c2a0c35ba5a54d03eeaff0ce3ca597cd0275",
     "zh:3411919ba2a5941801e677f0fea08bdd0ae22ba3c9ce3309f55554699e06524a",
     "zh:81b36138b8f2320dc7f877b50f9e38f4bc614affe68de885d322629dd0d16a29",

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -49,7 +49,7 @@ resource "helm_release" "ingress_nginx" {
   chart            = "ingress-nginx"
   version          = var.ingress_nginx_chart_version
   timeout          = var.helm_release_timeout_seconds
-  atomic           = true
+  atomic           = false
   cleanup_on_fail  = true
   wait             = true
 


### PR DESCRIPTION
## 관련 이슈
- Closes #35 

## 무엇을 만들었나요? (What)
- .github/workflows/trivy-pr-scan.yml 파일을 추가하여 컨테이너 이미지 스캔 파이프라인을 구축
main 브랜치로 향하는 Pull Request(PR) 생성 시, Trivy가 자동으로 실행되어 타겟 이미지(nginx:1.21)의 OS 및 라이브러리 취약점(CVE)을 스캔
- CRITICAL, HIGH 등급 취약점 발견 시 파이프라인을 강제 실패(Exit-code 1)시켜 배포를 원천 차단하고, MEDIUM, LOW, UNKNOWN 등급 취약점은 빌드를 차단하지 않되, GitHub Actions 봇이 PR 댓글로 스캔 결과를 리포트로 작성하도록 구성

## 왜 이렇게 만들었나요? (Why)
- 클러스터에 배포되기 전, CI 단계에서 선제적으로 취약점을 탐지하고 차단하여 잠재적인 보안 위협(RCE, 데이터 유출 등)을 방지하기 위함이다.
- 모든 취약점에 대해 빌드를 차단하면 개발 속도가 심각하게 저하된다. 따라서 즉각적인 조치가 필요한 고위험(High 이상)은 시스템적으로 통제하고, 저위험 취약점은 PR 댓글만 제공하여 자발적인 패치를 유도한다.


## 참고
- 타켓 이미지의 경우, 환경에 맞는 이미지로 작성하면 된다. 현재 실습 환경에서 발생하고 있는 statelock 및 argocd관련 오류로 namespace에 진입하지 못해 해결되면 다시 수정할 예정이다.
