### PR TITLE
[Feature] 데이터 보호: Workload 내 Hardcoded Secret 제거 (team-b)

### DIFF
--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -1,3 +1,16 @@
+resource "aws_ecr_registry_scanning_configuration" "this" {
+  scan_type = "BASIC"
+
+  rule {
+    scan_frequency = "SCAN_ON_PUSH"
+
+    repository_filter {
+      filter      = "*"
+      filter_type = "WILDCARD"
+    }
+  }
+}
+
 module "vpc" {
   source = "../../modules/vpc"
 

--- a/environments/platform/.terraform.lock.hcl
+++ b/environments/platform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 5.0"
   hashes = [
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",

--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -28,8 +28,12 @@ module "k8s_base" {
 module "namespaces" {
   source = "../../modules/namespaces"
 
-  project_name = var.project_name
-  team_names   = var.team_names
+  project_name         = var.project_name
+  team_names           = var.team_names
+  secret_enabled_teams = var.secret_enabled_teams
+  redis_password       = var.redis_password
+  postgres_password    = var.postgres_password
+  postgres_user        = var.postgres_user
 
   depends_on = [module.k8s_base]
 }

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -124,3 +124,27 @@ variable "team_names" {
   type        = list(string)
   default     = ["team-a", "team-b", "team-c", "team-d"]
 }
+
+variable "secret_enabled_teams" {
+  description = "Team namespaces where app-secrets Kubernetes Secret will be created."
+  type        = list(string)
+  default     = ["team-b"]
+}
+
+variable "redis_password" {
+  description = "Redis password injected into app-secrets Secret."
+  type        = string
+  sensitive   = true
+}
+
+variable "postgres_password" {
+  description = "External PostgreSQL password injected into app-secrets Secret."
+  type        = string
+  sensitive   = true
+}
+
+variable "postgres_user" {
+  description = "External PostgreSQL user injected into app-secrets Secret."
+  type        = string
+  sensitive   = true
+}

--- a/manifests/overlays/team-b/api-patch.yaml
+++ b/manifests/overlays/team-b/api-patch.yaml
@@ -8,18 +8,25 @@ spec:
       containers:
         - name: api
           env:
+            - $patch: replace
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:
                   name: app-secrets
                   key: redis-url
-            - name: EXTERNAL_POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: postgres-password
+            - name: EXTERNAL_POSTGRES_HOST
+              value: reporting-db.training.local
+            - name: EXTERNAL_POSTGRES_PORT
+              value: "5432"
+            - name: EXTERNAL_POSTGRES_DATABASE
+              value: reporting
             - name: EXTERNAL_POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: app-secrets
                   key: postgres-user
+            - name: EXTERNAL_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: postgres-password

--- a/manifests/overlays/team-b/api-patch.yaml
+++ b/manifests/overlays/team-b/api-patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          env:
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: redis-url
+            - name: EXTERNAL_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: postgres-password
+            - name: EXTERNAL_POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: postgres-user

--- a/manifests/overlays/team-b/db-patch.yaml
+++ b/manifests/overlays/team-b/db-patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+spec:
+  template:
+    spec:
+      containers:
+        - name: db
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: redis-password

--- a/manifests/overlays/team-b/db-patch.yaml
+++ b/manifests/overlays/team-b/db-patch.yaml
@@ -8,6 +8,7 @@ spec:
       containers:
         - name: db
           env:
+            - $patch: replace
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/manifests/overlays/team-b/kustomization.yaml
+++ b/manifests/overlays/team-b/kustomization.yaml
@@ -11,3 +11,11 @@ patches:
     target:
       kind: Ingress
       name: web
+  - path: db-patch.yaml
+    target:
+      kind: StatefulSet
+      name: db
+  - path: api-patch.yaml
+    target:
+      kind: Deployment
+      name: api

--- a/manifests/overlays/team-b/web-deployment-patch.yaml
+++ b/manifests/overlays/team-b/web-deployment-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.28-alpine

--- a/modules/namespaces/main.tf
+++ b/modules/namespaces/main.tf
@@ -9,3 +9,21 @@ resource "kubernetes_namespace_v1" "teams" {
     }
   }
 }
+
+resource "kubernetes_secret_v1" "app_secrets" {
+  for_each = toset(var.secret_enabled_teams)
+
+  metadata {
+    name      = "app-secrets"
+    namespace = each.value
+  }
+
+  data = {
+    redis-password    = var.redis_password
+    redis-url         = "redis://:${var.redis_password}@db:6379/0"
+    postgres-password = var.postgres_password
+    postgres-user     = var.postgres_user
+  }
+
+  depends_on = [kubernetes_namespace_v1.teams]
+}

--- a/modules/namespaces/variables.tf
+++ b/modules/namespaces/variables.tf
@@ -8,3 +8,30 @@ variable "team_names" {
   type        = list(string)
   default     = ["team-a", "team-b", "team-c", "team-d"]
 }
+
+variable "secret_enabled_teams" {
+  description = "Team namespaces where app-secrets Kubernetes Secret will be created."
+  type        = list(string)
+  default     = []
+}
+
+variable "redis_password" {
+  description = "Redis password injected into app-secrets Secret."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "postgres_password" {
+  description = "External PostgreSQL password injected into app-secrets Secret."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "postgres_user" {
+  description = "External PostgreSQL user injected into app-secrets Secret."
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #32 

## 무엇을 만들었나요? (What)
team-b 네임스페이스에 Terraform으로 Kubernetes Secret(app-secrets)을 생성하고, db/api 워크로드가 하드코딩된 패스워드 대신 secretKeyRef로 Secret을 참조하도록 변경했습니다.

## 왜 이렇게 만들었나요? (Why)
YAML 매니페스트에 평문 패스워드가 그대로 노출되면 Git 히스토리와 이미지 레이어를 통해 영구적으로 유출될 수 있어, 시크릿 값을 코드에서 분리하고 Kubernetes Secret을 통해 런타임에만 주입합니다.

## 테스트
### Step 1. 하드코딩된 시크릿 탐지

매니페스트에서 평문 패스워드 확인

`grep -r "password\|PASSWORD" manifests/base/`

<img width="809" height="148" alt="image (32)" src="https://github.com/user-attachments/assets/8a2959ad-75cb-4768-aac8-45be55243f99" />


실행 중인 Pod에서 env 확인 (평문 노출 확인)

`kubectl exec -n team-b deploy/api -- env | grep -i password`

<img width="702" height="86" alt="image (33)" src="https://github.com/user-attachments/assets/06c7be54-c51b-49d4-9891-d024a9ec4105" />


### Step 2. Terraform으로 Kubernetes Secret 생성

`cd environments/platform

AWS_PROFILE=team-b AWS_REGION=ap-northeast-2 terraform apply \
  -var="redis_password=training-password" \
  -var="postgres_password=training-external-password" \
  -var="postgres_user=training-api"`

### Step 3. Secret 생성 확인

Secret 존재 확인

`kubectl get secret app-secrets -n team-b`

<img width="666" height="76" alt="image (34)" src="https://github.com/user-attachments/assets/0e4c427c-cbde-4216-a9c4-e570281d1649" />


Secret 키 목록 확인 (값은 base64 인코딩)

`kubectl describe secret app-secrets -n team-b`

<img width="712" height="277" alt="image (35)" src="https://github.com/user-attachments/assets/d574d3f0-0c5d-4823-94a3-f23d58435c0f" />

값이 base64로 저장됐는지 확인 (평문 아님)

`kubectl get secret app-secrets -n team-b -o yaml`

<img width="700" height="297" alt="image (36)" src="https://github.com/user-attachments/assets/1d2e6d07-76e3-438d-af26-7f61936714b3" />


### Step 4. ArgoCD sync로 패치 적용

```bash
git add manifests/overlays/team-b/api-patch.yaml \
        manifests/overlays/team-b/db-patch.yaml \
        manifests/overlays/team-b/kustomization.yaml
        
git commit -m "feat: replace hardcoded secrets with secretKeyRef"
git push
```

ArgoCD sync

`kubectl -n argocd patch app team-b --type merge -p \
  '{"operation":{"sync":{"revision":"HEAD"}}}'

kubectl get app team-b -n argocd`

<img width="658" height="122" alt="image (37)" src="https://github.com/user-attachments/assets/45a3768f-8dfb-4423-9244-f13f5b758748" />


### Step 5. 적용 확인 — secretKeyRef로 변경됐는지 검증

Pod spec에서 value가 아닌 secretKeyRef 참조 확인

`kubectl get pod -n team-b -l app.kubernetes.io/name=api -o yaml | grep -A5 "REDIS_URL"`

<img width="726" height="170" alt="image (38)" src="https://github.com/user-attachments/assets/ab21bed0-b296-4dd2-8299-f79db5e65e53" />


Pod 정상 기동 확인

`kubectl get pods -n team-b`

env에서 평문 패스워드 제거됐는지 확인

`kubectl exec -n team-b deploy/api -- env | grep -i password`

<img width="716" height="151" alt="image (39)" src="https://github.com/user-attachments/assets/7ea8d776-8eb2-4062-9ef2-c6e05b96a16a" />

→ 값은 나오지만 매니페스트/Git에는 없음


