### PR TITLE
[Feat] 외부 진입점 TLS 인증서 자동 관리 (team-a)

### DIFF
--- a/environments/platform/acm.tf
+++ b/environments/platform/acm.tf
@@ -1,0 +1,47 @@
+locals {
+  create_ingress_acm_certificate = try(trimspace(var.ingress_lb_acm_certificate_arn), "") == ""
+}
+
+resource "aws_acm_certificate" "ingress" {
+  count = local.create_ingress_acm_certificate ? 1 : 0
+
+  domain_name               = var.ingress_certificate_domain_name
+  subject_alternative_names = var.ingress_certificate_subject_alternative_names
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+locals {
+  ingress_acm_domain_validation_option = local.create_ingress_acm_certificate ? one(aws_acm_certificate.ingress[0].domain_validation_options) : null
+}
+
+resource "cloudflare_dns_record" "ingress_acm_validation" {
+  count = local.create_ingress_acm_certificate ? 1 : 0
+
+  zone_id = var.cloudflare_zone_id
+  name    = trimsuffix(local.ingress_acm_domain_validation_option.resource_record_name, ".")
+  type    = local.ingress_acm_domain_validation_option.resource_record_type
+  content = trimsuffix(local.ingress_acm_domain_validation_option.resource_record_value, ".")
+  ttl     = 60
+  proxied = false
+}
+
+resource "aws_acm_certificate_validation" "ingress" {
+  count = local.create_ingress_acm_certificate ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.ingress[0].arn
+  validation_record_fqdns = ["${cloudflare_dns_record.ingress_acm_validation[0].name}."]
+}
+
+locals {
+  resolved_ingress_lb_acm_certificate_arn = local.create_ingress_acm_certificate ? aws_acm_certificate_validation.ingress[0].certificate_arn : var.ingress_lb_acm_certificate_arn
+}

--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -23,6 +23,7 @@ module "k8s_base" {
   aws_node_termination_handler_chart_version = var.aws_node_termination_handler_chart_version
   ingress_nginx_namespace                    = var.ingress_nginx_namespace
   ingress_nginx_chart_version                = var.ingress_nginx_chart_version
+  ingress_lb_acm_certificate_arn             = var.ingress_lb_acm_certificate_arn
 }
 
 module "namespaces" {

--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -23,7 +23,8 @@ module "k8s_base" {
   aws_node_termination_handler_chart_version = var.aws_node_termination_handler_chart_version
   ingress_nginx_namespace                    = var.ingress_nginx_namespace
   ingress_nginx_chart_version                = var.ingress_nginx_chart_version
-  ingress_lb_acm_certificate_arn             = var.ingress_lb_acm_certificate_arn
+  ingress_lb_acm_certificate_arn = local.resolved_ingress_lb_acm_certificate_arn
+
 }
 
 module "namespaces" {

--- a/environments/platform/outputs.tf
+++ b/environments/platform/outputs.tf
@@ -62,3 +62,8 @@ output "argocd_application_names" {
   description = "Generated team ArgoCD application names."
   value       = module.argocd.application_names
 }
+
+output "ingress_lb_acm_certificate_arn" {
+  description = "ACM certificate ARN attached to the ingress-nginx load balancer."
+  value       = local.resolved_ingress_lb_acm_certificate_arn
+}

--- a/environments/platform/providers.tf
+++ b/environments/platform/providers.tf
@@ -16,6 +16,11 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.0"
     }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
   }
 }
 
@@ -35,4 +40,9 @@ provider "helm" {
     cluster_ca_certificate = base64decode(data.terraform_remote_state.infra.outputs.cluster_certificate_authority_data)
     token                  = data.aws_eks_cluster_auth.infra.token
   }
+}
+
+provider "cloudflare" {
+  email   = var.cloudflare_email
+  api_key = var.cloudflare_api_key
 }

--- a/environments/platform/terraform.tfvars
+++ b/environments/platform/terraform.tfvars
@@ -13,4 +13,9 @@ argocd_chart_version         = "9.4.17"
 argocd_apps_chart_version    = "2.0.3"
 gitops_repo_url              = "https://github.com/K8RVIS/eks-secure-infra.git"
 
-ingress_lb_acm_certificate_arn = "arn:aws:acm:ap-northeast-2:357542025037:certificate/6e95b8cb-8e7a-44ac-a47d-be12cf7a413b"
+ingress_lb_acm_certificate_arn = null
+
+cloudflare_zone_id = "ae86e28ffa7d6b1f86584d8d106d7043"
+
+ingress_certificate_domain_name               = "*.terraform-study-esc.shop"
+ingress_certificate_subject_alternative_names = []

--- a/environments/platform/terraform.tfvars
+++ b/environments/platform/terraform.tfvars
@@ -12,3 +12,5 @@ ingress_nginx_chart_version  = "4.14.1"
 argocd_chart_version         = "9.4.17"
 argocd_apps_chart_version    = "2.0.3"
 gitops_repo_url              = "https://github.com/K8RVIS/eks-secure-infra.git"
+
+ingress_lb_acm_certificate_arn = "arn:aws:acm:ap-northeast-2:357542025037:certificate/6e95b8cb-8e7a-44ac-a47d-be12cf7a413b"

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -124,3 +124,8 @@ variable "team_names" {
   type        = list(string)
   default     = ["team-a", "team-b", "team-c", "team-d"]
 }
+
+variable "ingress_lb_acm_certificate_arn" {
+  description = "ACM certificate ARN used by the ingress-nginx AWS load balancer TLS listener."
+  type        = string
+}

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -126,6 +126,35 @@ variable "team_names" {
 }
 
 variable "ingress_lb_acm_certificate_arn" {
-  description = "ACM certificate ARN used by the ingress-nginx AWS load balancer TLS listener."
+  description = "Existing ACM certificate ARN. Leave null to create and validate one automatically."
   type        = string
+  default     = null
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID that hosts the ingress domain."
+  type        = string
+}
+
+variable "ingress_certificate_domain_name" {
+  description = "Primary ACM certificate domain name."
+  type        = string
+}
+
+variable "ingress_certificate_subject_alternative_names" {
+  description = "Additional ACM certificate domain names."
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudflare_email" {
+  description = "Cloudflare account email for Global API Key authentication."
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_api_key" {
+  description = "Cloudflare Global API Key."
+  type        = string
+  sensitive   = true
 }

--- a/manifests/overlays/team-a/web-ingress-patch.yaml
+++ b/manifests/overlays/team-a/web-ingress-patch.yaml
@@ -2,9 +2,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
+  tls:
+  - hosts:
+      - team-a.terraform-study-esc.shop
+    secretName: team-a-web-tls
   rules:
-    - host: team-a.training.local
+    - host: team-a.terraform-study-esc.shop
       http:
         paths:
           - path: /

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -62,6 +62,11 @@ resource "helm_release" "ingress_nginx" {
         type: LoadBalancer
         annotations:
           service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+          service.beta.kubernetes.io/aws-load-balancer-type: external
+          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: ${var.ingress_lb_acm_certificate_arn}
+          //service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+          service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
     EOT
   ]
 }

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -54,19 +54,25 @@ resource "helm_release" "ingress_nginx" {
   wait             = true
 
   values = [
-    <<-EOT
-    controller:
-      ingressClassResource:
-        default: true
-      service:
-        type: LoadBalancer
-        annotations:
-          service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-          service.beta.kubernetes.io/aws-load-balancer-type: external
-          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
-          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: ${var.ingress_lb_acm_certificate_arn}
-          //service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-          service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
-    EOT
+    yamlencode({
+      controller = {
+        ingressClassResource = {
+          default = true
+        }
+
+        service = {
+          type = "LoadBalancer"
+
+          annotations = {
+            "service.beta.kubernetes.io/aws-load-balancer-scheme"                 = "internet-facing"
+            "service.beta.kubernetes.io/aws-load-balancer-type"                   = "external"
+            "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"        = "instance"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-cert"               = var.ingress_lb_acm_certificate_arn
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-ports"              = "443"
+            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy" = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+          }
+        }
+      }
+    })
   ]
 }

--- a/modules/k8s-base/variables.tf
+++ b/modules/k8s-base/variables.tf
@@ -45,3 +45,8 @@ variable "ingress_nginx_chart_version" {
   type        = string
   default     = "4.14.1"
 }
+
+variable "ingress_lb_acm_certificate_arn" {
+  description = "ACM certificate ARN used by the ingress-nginx AWS load balancer TLS listener."
+  type        = string
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #26

## 무엇을 만들었나요? (What)
#29 PR을 기반으로 해당 작업을 진행하였다. 
- 외부 진입점 TLS 인증서를 Terraform으로 자동 요청/검증하도록 ACM 리소스를 추가하였다.
- ACM DNS 검증용 CNAME을 Cloudflare DNS에 자동 생성하도록 Cloudflare provider와 DNS record 리소스를 추가하였다.
- ACM 인증서가 ISSUED 상태가 될 때까지 Terraform이 대기한 뒤, 발급된 ACM ARN을 ingress-nginx LoadBalancer annotation에 연결하도록 하였다.
- 기존 수동 ACM ARN 입력 방식은 ingress_lb_acm_certificate_arn 값으로 유지하되, null일 경우 자동 발급 경로를 사용하도록 구성하였다. 
- Cloudflare 인증 정보는 코드에 저장하지 않고 환경변수/민감 변수로 주입하도록 구성하였다. 

## 왜 이렇게 만들었나요? (Why)
- 기존에는 ACM 인증서 ARN을 직접 입력해야 해서 인증서 교체나 재발급 시 수동 작업이 필요하였기에 이번 패치를 통해 Terraform → ACM 요청 → Cloudflare DNS 검증 → ACM 발급 완료 → LB annotation 연결 흐름을 자동화하여 TLS 인증서 관리 부담을 줄이고자 하였다. 
- #29 PR의 조인 ingress-nginx LoadBalancer 기반 TLS 강제 방식을 유지하면서, 인증서 발급과 검증만 자동화하는 방향으로 설계하였다. 
- DNS가 Cloudflare에서 관리되고 있으므로 ACM DNS 검증 CNAME도 Terraform Cloudflare provider를 통해 생성하도록 하였다. Cloudflare API token을 사용하면 보안 상 더 안전하지만 현재 계정 상 생성 권한이 없어 global api + email 조합을 이용하였다. 

## 테스트
<img width="1258" height="179" alt="image" src="https://github.com/user-attachments/assets/d85338f0-2b57-4798-9f05-77706a5e4fa3" />
terraform apply 시, 이와 같은 오류가 발생하였다. <br>
-> 확인해보니 현재 계정으로는 Cloudflare의 DNS 관리 권한이 부여되지 않아서 인증서를 생성할 수 없다고 한다. <br>
-> 해당 DNS zone 조회는 가능하지만, record 생성이 안되는 것이므로 DNS  권한이 있다면 정상적으로 실행될 것으로 판단된다. 

## 참고
아래와 같은 방법을 이용하여 환경변수로 주입이 가능하다. 
```
terraform -chdir=environments/platform apply `
   -var="cloudflare_email=$env:CLOUDFLARE_EMAIL" `
   -var="cloudflare_api_key=$env:CLOUDFLARE_API_KEY"
```

### Cloudflare API token 생성 방법
<img width="1347" height="1340" alt="스크린샷 2026-04-30 013620" src="https://github.com/user-attachments/assets/8c5e4fa3-99de-451e-9db3-a177794ee90c" />
