### PR TITLE
[Feat] Kubernetes API endpoint를 private-only 전환 (team-d)

### DIFF
--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -16,13 +16,14 @@ module "vpc" {
 module "eks" {
   source = "../../modules/eks"
 
-  project_name       = var.project_name
-  environment        = var.environment
-  owner              = var.owner
-  cluster_subnet_ids = module.vpc.private_subnet_ids
-  node_subnet_ids    = module.vpc.public_subnet_ids
-  kubernetes_version = var.kubernetes_version
-  node_ami_type      = var.node_ami_type
-  node_group         = var.node_group
-  default_tags       = var.default_tags
+  project_name                          = var.project_name
+  environment                           = var.environment
+  owner                                 = var.owner
+  cluster_subnet_ids                    = module.vpc.private_subnet_ids
+  node_subnet_ids                       = module.vpc.public_subnet_ids
+  cluster_private_endpoint_access_cidrs = var.cluster_private_endpoint_access_cidrs
+  kubernetes_version                    = var.kubernetes_version
+  node_ami_type                         = var.node_ami_type
+  node_group                            = var.node_group
+  default_tags                          = var.default_tags
 }

--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -16,14 +16,13 @@ module "vpc" {
 module "eks" {
   source = "../../modules/eks"
 
-  project_name                = var.project_name
-  environment                 = var.environment
-  owner                       = var.owner
-  cluster_subnet_ids          = module.vpc.private_subnet_ids
-  node_subnet_ids             = module.vpc.public_subnet_ids
-  cluster_public_access_cidrs = var.cluster_public_access_cidrs
-  kubernetes_version          = var.kubernetes_version
-  node_ami_type               = var.node_ami_type
-  node_group                  = var.node_group
-  default_tags                = var.default_tags
+  project_name       = var.project_name
+  environment        = var.environment
+  owner              = var.owner
+  cluster_subnet_ids = module.vpc.private_subnet_ids
+  node_subnet_ids    = module.vpc.public_subnet_ids
+  kubernetes_version = var.kubernetes_version
+  node_ami_type      = var.node_ami_type
+  node_group         = var.node_group
+  default_tags       = var.default_tags
 }

--- a/environments/infra/outputs.tf
+++ b/environments/infra/outputs.tf
@@ -53,6 +53,11 @@ output "cluster_security_group_id" {
   value       = module.eks.cluster_security_group_id
 }
 
+output "vpn_vpc_peering_connection_id" {
+  description = "VPC peering connection ID between the infra VPC and VPN VPC."
+  value       = module.vpn_peering.vpc_peering_connection_id
+}
+
 output "node_group_name" {
   description = "Name of the default infra EKS managed node group."
   value       = module.eks.node_group_name

--- a/environments/infra/terraform.tfvars
+++ b/environments/infra/terraform.tfvars
@@ -20,10 +20,6 @@ private_subnet_cidrs = [
   "10.0.20.0/24",
 ]
 
-cluster_public_access_cidrs = [
-  "13.125.215.119/32",
-]
-
 fck_nat_instance_type = "t4g.nano"
 
 default_tags = {

--- a/environments/infra/terraform.tfvars
+++ b/environments/infra/terraform.tfvars
@@ -20,6 +20,13 @@ private_subnet_cidrs = [
   "10.0.20.0/24",
 ]
 
+cluster_private_endpoint_access_cidrs = [
+  "172.31.0.0/16",
+]
+
+vpn_vpc_id   = "vpc-096c2102f9e82e7e2"
+vpn_vpc_cidr = "172.31.0.0/16"
+
 fck_nat_instance_type = "t4g.nano"
 
 default_tags = {

--- a/environments/infra/variables.tf
+++ b/environments/infra/variables.tf
@@ -38,11 +38,6 @@ variable "private_subnet_cidrs" {
   type        = list(string)
 }
 
-variable "cluster_public_access_cidrs" {
-  description = "CIDR blocks allowed to access the infra EKS public API endpoint."
-  type        = list(string)
-}
-
 variable "fck_nat_instance_type" {
   description = "Instance type for the fck-nat instance."
   type        = string

--- a/environments/infra/variables.tf
+++ b/environments/infra/variables.tf
@@ -38,6 +38,22 @@ variable "private_subnet_cidrs" {
   type        = list(string)
 }
 
+variable "cluster_private_endpoint_access_cidrs" {
+  description = "Private CIDR blocks allowed to access the infra EKS private API endpoint."
+  type        = list(string)
+  default     = []
+}
+
+variable "vpn_vpc_id" {
+  description = "Existing VPN VPC ID peered with the infra VPC for private EKS API access."
+  type        = string
+}
+
+variable "vpn_vpc_cidr" {
+  description = "CIDR block for the existing VPN VPC."
+  type        = string
+}
+
 variable "fck_nat_instance_type" {
   description = "Instance type for the fck-nat instance."
   type        = string

--- a/environments/infra/vpn-peering.tf
+++ b/environments/infra/vpn-peering.tf
@@ -1,0 +1,21 @@
+data "aws_route_tables" "vpn" {
+  vpc_id = var.vpn_vpc_id
+}
+
+module "vpn_peering" {
+  source = "../../modules/vpc-peering"
+
+  project_name = var.project_name
+  environment  = var.environment
+  owner        = var.owner
+
+  requester_vpc_id          = module.vpc.vpc_id
+  requester_vpc_cidr        = module.vpc.vpc_cidr
+  requester_route_table_ids = [module.vpc.private_route_table_id]
+
+  accepter_vpc_id          = var.vpn_vpc_id
+  accepter_vpc_cidr        = var.vpn_vpc_cidr
+  accepter_route_table_ids = data.aws_route_tables.vpn.ids
+
+  default_tags = var.default_tags
+}

--- a/modules/vpc-peering/.terraform.lock.hcl
+++ b/modules/vpc-peering/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/vpc-peering/main.tf
+++ b/modules/vpc-peering/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  name = "${var.project_name}-${var.environment}-vpn-peering"
+
+  common_tags = merge(
+    {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Owner       = var.owner
+      Module      = "vpc-peering"
+    },
+    var.default_tags
+  )
+}
+
+resource "aws_vpc_peering_connection" "this" {
+  vpc_id      = var.requester_vpc_id
+  peer_vpc_id = var.accepter_vpc_id
+  auto_accept = true
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = local.name
+    }
+  )
+}
+
+resource "aws_vpc_peering_connection_options" "this" {
+  vpc_peering_connection_id = aws_vpc_peering_connection.this.id
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
+resource "aws_route" "requester_to_accepter" {
+  for_each = toset(var.requester_route_table_ids)
+
+  route_table_id            = each.value
+  destination_cidr_block    = var.accepter_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.this.id
+}
+
+resource "aws_route" "accepter_to_requester" {
+  for_each = toset(var.accepter_route_table_ids)
+
+  route_table_id            = each.value
+  destination_cidr_block    = var.requester_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.this.id
+}

--- a/modules/vpc-peering/outputs.tf
+++ b/modules/vpc-peering/outputs.tf
@@ -1,0 +1,4 @@
+output "vpc_peering_connection_id" {
+  description = "ID of the VPC peering connection."
+  value       = aws_vpc_peering_connection.this.id
+}

--- a/modules/vpc-peering/tests/routes.tftest.hcl
+++ b/modules/vpc-peering/tests/routes.tftest.hcl
@@ -1,0 +1,51 @@
+mock_provider "aws" {
+  override_during = plan
+}
+
+variables {
+  project_name = "eks-secure-infra"
+  environment  = "dev"
+  owner        = "K8RVIS"
+
+  requester_vpc_id          = "vpc-eks"
+  requester_vpc_cidr        = "10.0.0.0/16"
+  requester_route_table_ids = ["rtb-eks-private"]
+
+  accepter_vpc_id          = "vpc-vpn"
+  accepter_vpc_cidr        = "172.31.0.0/16"
+  accepter_route_table_ids = ["rtb-vpn-a", "rtb-vpn-b"]
+
+  default_tags = {
+    Repository = "eks-secure-infra"
+    ManagedBy  = "terraform"
+  }
+}
+
+run "creates_bidirectional_vpc_peering_routes" {
+  command = plan
+
+  assert {
+    condition     = aws_vpc_peering_connection.this.vpc_id == var.requester_vpc_id && aws_vpc_peering_connection.this.peer_vpc_id == var.accepter_vpc_id
+    error_message = "VPC peering must connect the requester EKS VPC to the accepter VPN VPC."
+  }
+
+  assert {
+    condition     = aws_vpc_peering_connection.this.auto_accept == true
+    error_message = "Same-account VPN peering must be auto-accepted."
+  }
+
+  assert {
+    condition     = aws_route.requester_to_accepter["rtb-eks-private"].route_table_id == "rtb-eks-private" && aws_route.requester_to_accepter["rtb-eks-private"].destination_cidr_block == "172.31.0.0/16"
+    error_message = "The requester route table must route VPN VPC CIDR through the peering connection."
+  }
+
+  assert {
+    condition     = aws_route.accepter_to_requester["rtb-vpn-a"].route_table_id == "rtb-vpn-a" && aws_route.accepter_to_requester["rtb-vpn-a"].destination_cidr_block == "10.0.0.0/16"
+    error_message = "Each VPN route table must route EKS VPC CIDR through the peering connection."
+  }
+
+  assert {
+    condition     = aws_vpc_peering_connection_options.this.requester[0].allow_remote_vpc_dns_resolution && aws_vpc_peering_connection_options.this.accepter[0].allow_remote_vpc_dns_resolution
+    error_message = "VPC peering must allow remote VPC DNS resolution in both directions."
+  }
+}

--- a/modules/vpc-peering/variables.tf
+++ b/modules/vpc-peering/variables.tf
@@ -1,0 +1,50 @@
+variable "project_name" {
+  description = "Project identifier used in tags and naming."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name used in tags and naming."
+  type        = string
+}
+
+variable "owner" {
+  description = "Owner tag applied to VPC peering resources."
+  type        = string
+}
+
+variable "requester_vpc_id" {
+  description = "Requester VPC ID, typically the EKS workload VPC."
+  type        = string
+}
+
+variable "requester_vpc_cidr" {
+  description = "CIDR block for the requester VPC."
+  type        = string
+}
+
+variable "requester_route_table_ids" {
+  description = "Route table IDs in the requester VPC that need routes to the accepter VPC."
+  type        = list(string)
+}
+
+variable "accepter_vpc_id" {
+  description = "Accepter VPC ID, typically the existing VPN VPC."
+  type        = string
+}
+
+variable "accepter_vpc_cidr" {
+  description = "CIDR block for the accepter VPC."
+  type        = string
+}
+
+variable "accepter_route_table_ids" {
+  description = "Route table IDs in the accepter VPC that need routes to the requester VPC."
+  type        = list(string)
+}
+
+variable "default_tags" {
+  description = "Additional tags merged into all VPC peering resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #67 

## 무엇을 만들었나요? (What)
- EKS API endpoint를 private-only로 전환
  - `endpoint_private_access = true`
  - `endpoint_public_access = false`
  - 기존 `cluster_public_access_cidrs` 제거

- VPN VPC에서 EKS private API endpoint로 접근 가능하도록 보안 그룹 규칙 추가
  - VPN VPC CIDR: `172.31.0.0/16`
  - EKS cluster security group ingress: TCP 443 허용

- EKS VPC와 기존 VPN VPC 간 VPC Peering 추가
  - VPN VPC ID: `vpc-096c2102f9e82e7e2`
  - VPN VPC CIDR: `172.31.0.0/16`
  - EKS VPC CIDR: `10.0.0.0/16`

- 양방향 route 추가
  - EKS private route table -> VPN VPC CIDR
  - VPN VPC route table -> EKS VPC CIDR

- VPC Peering DNS 옵션 활성화
  - requester/accepter 모두 `allow_remote_vpc_dns_resolution = true`

## 왜 이렇게 만들었나요? (Why)

기존 구성은 EKS API Server public endpoint가 활성화되어 있었고, 접근 CIDR을 VPN egress IP `/32`로 제한하고 있었습니다.

이 구성은 인터넷 전체 노출은 줄이지만, `endpointPublicAccess = true` 상태이므로 Kubernetes API Server의 public 접근면은 여전히 남습니다. VPN egress IP를 공유하는 주체, VPN 계정 탈취, CIDR 예외 확대, 운영 중 임시 허용 같은 리스크도 남습니다.

VPN IP 제한은 IP 기반 통제라서 identity 기반 네트워크 통제가 아닙니다. 지금은 13.125.215.119/32에서 오는 요청만 허용됩니다. 하지만 그 IP 뒤에 있는 모든 VPN 사용자, VPN 경유 시스템, 잘못 구성된 프록시, 탈취된 VPN 계정은 API endpoint까지 도달할 수 있습니다. 즉, “인터넷 전체”는 막았지만 “VPN egress를 공유하는 모든 주체”는 Kubernetes API 인증면까지 닿습니다. private-only로 바꾸면 단순 egress IP가 아니라 VPC routing가 아니라 VPC routing, 연결망, 보안 그룹, 내부 DNS 조건을 모두 만족해야 합니다.

또한 public endpoint는 cluster security group으로 통제되지 않습니다. AWS 문서에 따르면 cluster security group은 private endpoint에는 적용되지만 public endpoint에는 영향을 주지 않습니다. public endpoint는 publicAccessCidrs로만 제어됩니다. public endpoint를 사용한다면 네트워크 통제가 “보안 그룹 기반 세밀한 통제”가 아니라 “허용 CIDR 목록”에 의존합니다. private-only가 되면 cluster security group으로 private endpoint 접근을 통제할 수 있습니다.

그리고 운영 중 CIDR을 완화해야 하는 경우가 생길 수 있습니다. (CI가 안 되어서 임시로 CIDR를 추가한다든지, 외부 GitOps/운영 도구 추가해서 public 접근을 연다든지) 이 경우 CIDR 완화가 리스크가 되기 쉽습니다. private-only는 이런 예외를 구조적으로 줄입니다. 접근해야 하는 CI/GitOps/운영 도구를 VPC 내부, peering, VPN, Direct Connect, bastion, Session Manager 경로 안에 두도록 강제합니다.

private-only 전환을 통해 API Server 접근 경로를 VPC 내부 또는 연결된 사설망으로 제한하고, VPN VPC와 EKS VPC 사이의 사설 라우팅 경로를 명시적으로 구성했습니다.

## 테스트

### 적용 전 취약점 테스트

<img width="1495" height="313" alt="image" src="https://github.com/user-attachments/assets/4234ffc8-2862-43f1-8bdd-bbe033a30143" />
API 서버 엔드포인트 엑세스가 퍼블릭임

<br>

<img width="515" height="234" alt="image" src="https://github.com/user-attachments/assets/d4c1b618-b9da-4322-b44a-2c73da952249" />
VPC에 publicAccessCidrs이 열려 있음 (단, IP는 VPN인 13.125.215.119/32만 접근 가능)

<br>

<img width="738" height="186" alt="image" src="https://github.com/user-attachments/assets/50c11150-1630-41fb-ba8d-740e3fd1319b" />
200 또는 Kubernetes API 응답 = VPN egress IP에서 public endpoint까지 네트워크 도달이 가능한 상태라는 의미

<br>

### 적용 후 확인

<img width="1314" height="204" alt="image" src="https://github.com/user-attachments/assets/37c31eb5-06fc-4cc0-bdeb-1e28750f949b" />
API 서버 엔드포인트 엑세스가 프라이빗임

<br>

<img width="719" height="183" alt="image" src="https://github.com/user-attachments/assets/8fbf0498-ee3c-4062-bb20-25e3227995fd" />
public access CIDR을 삭제했기 때문에 외부에서 접속이 불가하므로 000으로 연결 자체가 차단된 것을 확인 가능함

<br>

<img width="726" height="182" alt="image" src="https://github.com/user-attachments/assets/7ac7b325-ed7c-4baf-8231-7656006f1fea" />
vpn을 켜고 접근하면 200으로 연결이 잘 되는 것을 확인할 수 있음

<br>

## 참고
- private-only 전환 후에는 VPN/VPC Peering 경로, DNS 해석, SG rule 중 하나라도 누락되면 kubectl 접근이 실패할 수 있습니다.
