### PR TITLE
[Feat] Worker node, Pod를 private subnet 배치 (team-d)

### DIFF
--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -16,14 +16,14 @@ module "vpc" {
 module "eks" {
   source = "../../modules/eks"
 
-  project_name                = var.project_name
-  environment                 = var.environment
-  owner                       = var.owner
-  cluster_subnet_ids          = module.vpc.private_subnet_ids
-  node_subnet_ids             = module.vpc.public_subnet_ids
-  cluster_public_access_cidrs = var.cluster_public_access_cidrs
-  kubernetes_version          = var.kubernetes_version
-  node_ami_type               = var.node_ami_type
-  node_group                  = var.node_group
-  default_tags                = var.default_tags
+  project_name                          = var.project_name
+  environment                           = var.environment
+  owner                                 = var.owner
+  cluster_subnet_ids                    = module.vpc.private_subnet_ids
+  node_subnet_ids                       = module.vpc.private_subnet_ids
+  cluster_private_endpoint_access_cidrs = var.cluster_private_endpoint_access_cidrs
+  kubernetes_version                    = var.kubernetes_version
+  node_ami_type                         = var.node_ami_type
+  node_group                            = var.node_group
+  default_tags                          = var.default_tags
 }

--- a/environments/infra/outputs.tf
+++ b/environments/infra/outputs.tf
@@ -23,9 +23,24 @@ output "fck_nat_instance_id" {
   value       = module.vpc.fck_nat_instance_id
 }
 
+output "fck_nat_subnet_id" {
+  description = "Subnet ID where the fck-nat instance is placed."
+  value       = module.vpc.fck_nat_subnet_id
+}
+
+output "fck_nat_primary_network_interface_id" {
+  description = "Primary network interface ID of the fck-nat instance."
+  value       = module.vpc.fck_nat_primary_network_interface_id
+}
+
 output "fck_nat_ami_id" {
   description = "Automatically selected AMI ID for the fck-nat instance."
   value       = module.vpc.fck_nat_ami_id
+}
+
+output "private_default_route_network_interface_id" {
+  description = "Network interface ID targeted by the private default route."
+  value       = module.vpc.private_default_route_network_interface_id
 }
 
 output "cluster_name" {
@@ -53,6 +68,11 @@ output "cluster_security_group_id" {
   value       = module.eks.cluster_security_group_id
 }
 
+output "cluster_subnet_ids" {
+  description = "Subnet IDs used by the infra EKS control plane."
+  value       = module.eks.cluster_subnet_ids
+}
+
 output "node_group_name" {
   description = "Name of the default infra EKS managed node group."
   value       = module.eks.node_group_name
@@ -61,4 +81,9 @@ output "node_group_name" {
 output "node_group_arn" {
   description = "ARN of the default infra EKS managed node group."
   value       = module.eks.node_group_arn
+}
+
+output "node_subnet_ids" {
+  description = "Subnet IDs used by the default infra EKS managed node group."
+  value       = module.eks.node_subnet_ids
 }

--- a/environments/infra/terraform.tfvars
+++ b/environments/infra/terraform.tfvars
@@ -20,8 +20,8 @@ private_subnet_cidrs = [
   "10.0.20.0/24",
 ]
 
-cluster_public_access_cidrs = [
-  "13.125.215.119/32",
+cluster_private_endpoint_access_cidrs = [
+  "10.0.0.0/16",
 ]
 
 fck_nat_instance_type = "t4g.nano"

--- a/environments/infra/variables.tf
+++ b/environments/infra/variables.tf
@@ -38,8 +38,8 @@ variable "private_subnet_cidrs" {
   type        = list(string)
 }
 
-variable "cluster_public_access_cidrs" {
-  description = "CIDR blocks allowed to access the infra EKS public API endpoint."
+variable "cluster_private_endpoint_access_cidrs" {
+  description = "Private CIDR blocks allowed to access the infra EKS private API endpoint."
   type        = list(string)
 }
 

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -108,8 +108,7 @@ resource "aws_eks_cluster" "this" {
   vpc_config {
     subnet_ids              = var.cluster_subnet_ids
     endpoint_private_access = true
-    endpoint_public_access  = true
-    public_access_cidrs     = var.cluster_public_access_cidrs
+    endpoint_public_access  = false
   }
 
   depends_on = [
@@ -122,6 +121,18 @@ resource "aws_eks_cluster" "this" {
       Name = local.cluster_name
     }
   )
+}
+
+resource "aws_security_group_rule" "cluster_private_endpoint_ingress" {
+  for_each = toset(var.cluster_private_endpoint_access_cidrs)
+
+  type              = "ingress"
+  security_group_id = aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = [each.value]
+  description       = "Allow private EKS API endpoint access from ${each.value}"
 }
 
 resource "aws_launch_template" "node_group" {

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -23,6 +23,11 @@ output "cluster_security_group_id" {
   value       = aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
 }
 
+output "cluster_subnet_ids" {
+  description = "Subnet IDs used by the EKS control plane."
+  value       = var.cluster_subnet_ids
+}
+
 output "node_group_name" {
   description = "Name of the default managed node group."
   value       = aws_eks_node_group.this.node_group_name
@@ -36,4 +41,9 @@ output "node_group_arn" {
 output "node_group_role_arn" {
   description = "IAM role ARN used by the default managed node group."
   value       = aws_iam_role.node.arn
+}
+
+output "node_subnet_ids" {
+  description = "Subnet IDs used by the default managed node group."
+  value       = var.node_subnet_ids
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -33,18 +33,19 @@ variable "node_subnet_ids" {
   }
 }
 
-variable "cluster_public_access_cidrs" {
-  description = "CIDR blocks allowed to access the EKS public API endpoint."
+variable "cluster_private_endpoint_access_cidrs" {
+  description = "Private CIDR blocks allowed to access the EKS private API endpoint through the cluster security group."
   type        = list(string)
+  default     = []
 
   validation {
-    condition     = length(var.cluster_public_access_cidrs) > 0
-    error_message = "At least one CIDR must be supplied for the EKS public API endpoint."
+    condition     = alltrue([for cidr in var.cluster_private_endpoint_access_cidrs : can(cidrhost(cidr, 0))])
+    error_message = "Each private endpoint access CIDR must be a valid CIDR block."
   }
 
   validation {
-    condition     = !contains(var.cluster_public_access_cidrs, "0.0.0.0/0") && !contains(var.cluster_public_access_cidrs, "::/0")
-    error_message = "Do not allow 0.0.0.0/0 or ::/0 for the EKS public API endpoint."
+    condition     = !contains(var.cluster_private_endpoint_access_cidrs, "0.0.0.0/0") && !contains(var.cluster_private_endpoint_access_cidrs, "::/0")
+    error_message = "Do not allow 0.0.0.0/0 or ::/0 to the EKS private API endpoint."
   }
 }
 

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -43,7 +43,22 @@ output "fck_nat_instance_id" {
   value       = aws_instance.fck_nat.id
 }
 
+output "fck_nat_subnet_id" {
+  description = "Subnet ID where the fck-nat instance is placed."
+  value       = aws_instance.fck_nat.subnet_id
+}
+
+output "fck_nat_primary_network_interface_id" {
+  description = "Primary network interface ID of the fck-nat instance."
+  value       = aws_instance.fck_nat.primary_network_interface_id
+}
+
 output "fck_nat_ami_id" {
   description = "Automatically selected AMI ID for the fck-nat instance."
   value       = data.aws_ami.fck_nat.id
+}
+
+output "private_default_route_network_interface_id" {
+  description = "Network interface ID targeted by the private default route."
+  value       = aws_route.private_default.network_interface_id
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #69 

## 무엇을 만들었나요? (What)
- `environments/infra`에서 EKS control plane과 managed node group 모두 private_subnet을 사용하도록 수정

## 왜 이렇게 만들었나요? (Why)

EKS worker node가 Public Subnet에 배치되거나 Public IP를 가지면 외부 스캐닝, 취약한 데몬, 잘못 열린 포트, Security Group 오구성의 영향을 직접 받을 수 있습니다. 따라서 인터넷과 직접 연결되는 리소스를 최소화하고, EKS control plane 연결 subnet과 managed node group은 Private Subnet을 사용하도록 수정합니다.

## 테스트

### 적용 전 취약점 확인

<img width="1101" height="185" alt="스크린샷 2026-05-07 오전 2 22 29" src="https://github.com/user-attachments/assets/490b802b-0183-4691-9e68-f6af256a3c20" />
<img width="2634" height="1100" alt="image" src="https://github.com/user-attachments/assets/6e058e49-997f-4098-ac99-dd0443b805f8" />
eks-secure-infra-dev-spot(노드 그룹)이 public subnet을 사용 중인 것을 콘솔에서 확인할 수 있다.

<br>

### 적용 후 확인

<img width="1314" height="598" alt="image" src="https://github.com/user-attachments/assets/2af19bad-9b80-43a6-9288-560fe48ea32c" />
node_subnet_ids = private_subnet_ids인 것으로 보아 노드 그룹의 서브넷이 private subnet으로 변한 것을 확인할 수 있다.
또한 cluster_subnet_ids(private subnet) != fck_nat_subnet_id(public subnet)인 것을 통해 클러스터의 내부 통신은 private subnet에서, 내부에서 외부로 통신할 때 사용되는 nat는 public subnet에 있는 것을 확인할 수 있다.

