### PR TITLE
[Feat] default deny Network policy 적용 (team-a)

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - web
   - api
   - db
+  - network-policies

--- a/manifests/base/network-policies/allow-api-egress-to-db.yaml
+++ b/manifests/base/network-policies/allow-api-egress-to-db.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-egress-to-db
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: db
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/manifests/base/network-policies/allow-api-ingress-from-web.yaml
+++ b/manifests/base/network-policies/allow-api-ingress-from-web.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-ingress-from-web
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: web
+      ports:
+        - protocol: TCP
+          port: 80

--- a/manifests/base/network-policies/allow-db-ingress-from-api.yaml
+++ b/manifests/base/network-policies/allow-db-ingress-from-api.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-db-ingress-from-api
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: api
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/manifests/base/network-policies/allow-dns-egress.yaml
+++ b/manifests/base/network-policies/allow-dns-egress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/manifests/base/network-policies/allow-web-egress-to-api.yaml
+++ b/manifests/base/network-policies/allow-web-egress-to-api.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-web-egress-to-api
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: api
+      ports:
+        - protocol: TCP
+          port: 80

--- a/manifests/base/network-policies/allow-web-ingress-from-vpc.yaml
+++ b/manifests/base/network-policies/allow-web-ingress-from-vpc.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-web-ingress-from-vpc
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.0.0.0/16
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/manifests/base/network-policies/kustomization.yaml
+++ b/manifests/base/network-policies/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - allow-dns-egress.yaml
+  - allow-web-ingress-from-vpc.yaml
+  - allow-web-egress-to-api.yaml
+  - allow-api-ingress-from-web.yaml
+  - allow-api-egress-to-db.yaml
+  - allow-db-ingress-from-api.yaml

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -228,3 +228,30 @@ resource "aws_eks_addon" "ebs_csi_driver" {
     }
   )
 }
+
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name = aws_eks_cluster.this.name
+  addon_name   = "vpc-cni"
+
+  configuration_values = jsonencode({
+    enableNetworkPolicy = "true"
+    nodeAgent = {
+      healthProbeBindAddr = "8163"
+      metricsBindAddr     = "8162"
+    }
+  })
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+
+  depends_on = [
+    aws_eks_node_group.this,
+  ]
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.cluster_name}-vpc-cni"
+    }
+  )
+}

--- a/modules/namespaces/main.tf
+++ b/modules/namespaces/main.tf
@@ -57,3 +57,35 @@ resource "kubernetes_limit_range" "teams" {
     }
   }
 }
+
+resource "kubernetes_network_policy_v1" "default_deny_ingress" {
+  for_each = toset(var.team_names)
+
+  metadata {
+    name      = "default-deny-ingress"
+    namespace = each.value
+  }
+
+  spec {
+    pod_selector {}
+    policy_types = ["Ingress"]
+  }
+
+  depends_on = [kubernetes_namespace_v1.teams]
+}
+
+resource "kubernetes_network_policy_v1" "default_deny_egress" {
+  for_each = toset(var.team_names)
+
+  metadata {
+    name      = "default-deny-egress"
+    namespace = each.value
+  }
+
+  spec {
+    pod_selector {}
+    policy_types = ["Egress"]
+  }
+
+  depends_on = [kubernetes_namespace_v1.teams]
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #73

## 무엇을 만들었나요? (What)
- EKS VPC CNI managed add-on을 Terraform 관리 대상으로 추가하고 NetworkPolicy 를 활성화했다.
- 모든 팀 워크로드 namespace에 기본 차단 NetworkPolicy를 적용하도록 `modules/namespaces`에 정책을 추가하였다.
- Kustomize base에 앱 통신 을 위한 allow NetworkPolicy 디렉터리를 추가했다.
  - DNS egress 허용
  - VPC/ALB -> web ingress 허용
  - web -> api 통신 허용
  - api -> db 통신 허용

## 왜 이렇게 만들었나요? (Why)
- Kubernetes NetworkPolicy는 CNI가 집행을 지원하고 활성화되어야 실제 트래픽 차단이 동작하므로, 먼저 VPC CNI의 NetworkPolicy 기능을 Terraform으로 활성화했다.
- NetworkPolicy는 namespace-scoped 리소스이기 때문에 `team-a`, `team-b`, `team-c`, `team-d` 같은 워크로드 namespace별로 default deny가 각각 적용되어야 한다.
- default deny는 namespace 보안 기본값이므로 Terraform namespace 모듈에서 보장하고, 앱별 allow policy는 `web`, `api`, `db` 라벨과 포트에 의존하므로 Kustomize base에서 관리하도록 분리했다.
- egress default deny 적용 시 DNS도 차단되므로 CoreDNS TCP/UDP 53 통신을 명시적으로 허용했다.
- 필요한 통신만 열기 위해 `ALB/VPC -> web -> api -> db` 경로만 허용했다.

## 테스트
### NetworkPolicy 활성화 확인
<img width="728" height="100" alt="image" src="https://github.com/user-attachments/assets/344d6a37-21ce-4656-ae04-a326ed961404" />
<br>

<img width="448" height="135" alt="image" src="https://github.com/user-attachments/assets/318c5155-2fc0-4520-9b74-5b07448baf82" />
team-a namespace에 대해 networkpolicy가 적용되었음을 확인

<img width="424" height="51" alt="image" src="https://github.com/user-attachments/assets/1ab81ca4-f997-47b8-a3bc-4f8d4327df6d" />
net-test라는 Pod에서 CoreDNS에 정상적으로 질의하고 주소를 받아온 것을 알 수 있다.
<br>

<img width="424" height="51" alt="image" src="https://github.com/user-attachments/assets/2d4a7a1d-c44e-4b12-a136-03288edad4e3" />
다음과 같이 net-test Pod에서는 web 라벨이 없었기에 api로의 접근이 막힌 것을 알 수 있다. 
<br>

<img width="1389" height="234" alt="image" src="https://github.com/user-attachments/assets/e6c52bc7-9a5e-4112-971c-984fbbc54b00" />
web 라벨을 갖는 Pod를 만든 후 api접근이 되는지를 확인해보면 정상적으로 접근이 되는 것을 확인할 수 있다. 
<br>

<img width="1127" height="440" alt="image" src="https://github.com/user-attachments/assets/c83c34ce-4c4c-4e1a-8380-16643948da14" />
다음과 같이 api에서 db로의 접근도 가능한 것을 확인할 수 있다. 

## 참고
- 현재 클러스터에는 team-a namespace만 존재하여, 우선 team-a 기준으로 동작을 검증했다.
- 추후 team-b, team-c, team-d는 namespace 생성 후 동일한 overlay와 NetworkPolicy 검증이 필요하다.
