### PR TITLE
[Feat] 기본 deny NetworkPolicy 적용 (team-d)

### DIFF
--- a/manifests/overlays/team-d/kustomization.yaml
+++ b/manifests/overlays/team-d/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - api-serviceaccount.yaml
   - web-serviceaccount.yaml
   - db-serviceaccount.yaml
+  - network-policies.yaml
 
 patches:
   - path: web-ingress-patch.yaml

--- a/manifests/overlays/team-d/network-policies.yaml
+++ b/manifests/overlays/team-d/network-policies.yaml
@@ -1,0 +1,146 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  labels:
+    training.k8rvis.io/network-policy-phase: team-d-only
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  labels:
+    training.k8rvis.io/network-policy-phase: team-d-only
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  labels:
+    training.k8rvis.io/network-policy-phase: team-d-only
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-public-ingress-to-web
+  labels:
+    training.k8rvis.io/network-policy-phase: team-d-only
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-web-to-api
+  labels:
+    training.k8rvis.io/network-policy-phase: team-d-only
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: api
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-ingress-from-web
+  labels:
+    training.k8rvis.io/network-policy-phase: team-d-only
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: web
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-to-db
+  labels:
+    training.k8rvis.io/network-policy-phase: team-d-only
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: db
+      ports:
+        - protocol: TCP
+          port: 6379
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-db-ingress-from-api
+  labels:
+    training.k8rvis.io/network-policy-phase: team-d-only
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: api
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -124,6 +124,26 @@ resource "aws_eks_cluster" "this" {
   )
 }
 
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = "vpc-cni"
+  configuration_values        = jsonencode({ enableNetworkPolicy = "true" })
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_iam_role_policy_attachment.node_cni_policy,
+  ]
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.cluster_name}-vpc-cni"
+    }
+  )
+}
+
 resource "aws_launch_template" "node_group" {
   name_prefix            = "${local.node_group_name}-"
   update_default_version = true
@@ -199,6 +219,7 @@ resource "aws_eks_node_group" "this" {
   }
 
   depends_on = [
+    aws_eks_addon.vpc_cni,
     aws_iam_role_policy_attachment.node_worker_policy,
     aws_iam_role_policy_attachment.node_cni_policy,
     aws_iam_role_policy_attachment.node_ecr_policy,


### PR DESCRIPTION
## 관련 이슈
- Closes #73 

## 무엇을 만들었나요? (What)
- `team-d` Namespace에만 적용되는 default deny NetworkPolicy 실습 구성을 추가했습니다.
  - `default-deny-ingress`
  - `default-deny-egress`
  - `allow-dns-egress`
  - `allow-public-ingress-to-web`
  - `allow-web-to-api`
  - `allow-api-ingress-from-web`
  - `allow-api-to-db`
  - `allow-db-ingress-from-api`
- `team-d` Kustomize overlay에 NetworkPolicy 리소스를 포함했습니다.

## 왜 이렇게 만들었나요? (Why)
- Kubernetes는 기본적으로 Pod 간 통신이 넓게 허용되므로, 취약한 Pod가 내부 서비스나 데이터 계층으로 lateral movement를 시도할 수 있습니다.
- NetworkPolicy의 기본 보안 모델은 기본 차단 후 필요한 통신만 허용하는 것이므로, 먼저 team-d Namespace에서 default deny ingress/egress를 적용하고 필수 통신만 명시적으로 열었습니다.
- DNS, ALB 진입, `web -> api`, `api -> db` 흐름을 명시적으로 허용해 기본 차단 상태에서도 애플리케이션의 필수 경로는 유지되도록 했습니다.

## 테스트

### 적용 이전 취약점 확인

<img width="1396" height="158" alt="image" src="https://github.com/user-attachments/assets/931196ea-fad6-4c4e-9a89-b178663efe4b" />
실습 환경(team-d) namespace에 NetworkPolicy가 없는 것을 확인했다.

<img width="2330" height="254" alt="image" src="https://github.com/user-attachments/assets/f1c2be1a-1922-4450-b5db-5e84161c5bb3" />
실습 환경(team-d) namespce에서 Kubernetes API 등으로 접근이 가능한 것을 확인할 수 있다.

<img width="1486" height="548" alt="image" src="https://github.com/user-attachments/assets/c39506b3-21d3-4e84-86a4-46f0681f0605" />
임의로 띄운 테스트용 pod에서 web, api, db pod로의 통신이 가능한 것을 확인할 수 있다.

<br>

### 적용 이후 확인

<img width="739" height="567" alt="스크린샷 2026-05-07 오전 3 33 53" src="https://github.com/user-attachments/assets/f8c80d55-edde-4b61-8a09-ca23ae950740" />
NetworkPolicy가 적용된 것을 확인할 수 있다.

<img width="1640" height="604" alt="image" src="https://github.com/user-attachments/assets/6d4e3220-9c32-41de-9728-4c5fec300e3b" />
적용된 정책 세트를 확인할 수 있다.

<img width="1810" height="546" alt="image" src="https://github.com/user-attachments/assets/25b9de0d-2a77-4f93-a9e8-0f8d961ab078" />
DNS 조회는 성공하지만 임의로 띄운 테스트용 pod에서 web, api, db pod로의 통신 및 Kubernetes API 접근이 불가능한 것을 확인할 수 있다.

## 참고

- 실제 NetworkPolicy 차단은 CNI가 정책 집행을 지원해야 동작합니다.
- EKS에서는 Amazon VPC CNI NetworkPolicy 기능, Cilium, Calico 같은 정책 엔진이 필요합니다.