### PR TITLE
[Feat] work node, pod 를 private subnet에 배치 (team-a)

### DIFF
--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -20,7 +20,7 @@ module "eks" {
   environment                 = var.environment
   owner                       = var.owner
   cluster_subnet_ids          = module.vpc.private_subnet_ids
-  node_subnet_ids             = module.vpc.public_subnet_ids
+  node_subnet_ids             = module.vpc.private_subnet_ids
   cluster_public_access_cidrs = var.cluster_public_access_cidrs
   kubernetes_version          = var.kubernetes_version
   node_ami_type               = var.node_ami_type

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -95,7 +95,10 @@ resource "helm_release" "ingress_nginx" {
       service:
         type: LoadBalancer
         annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: external
+          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
           service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+
     EOT
   ]
 


### PR DESCRIPTION
## 관련 이슈
- Closes #69

## 무엇을 만들었나요? (What)
- EKS managed node group이 public subnet이 아닌 private subnet에 생성되도록 하였다.

## 왜 이렇게 만들었나요? (Why)
- worker node와 pod가 public subnet에 위치하면 외부 노출 위험이 커지므로, private subnet에 배치해 직접적인 인터넷 접근을 차단하기 위해 변경했다.
- 외부 사용자의 inbound 트래픽은 public subnet의 internet-facing NLB를 통해서만 들어오도록 구성했다.
- private subnet의 node/pod가 외부로 나가는 outbound 트래픽은 기존 VPC 구성의 fck-nat 경로를 사용한다.

  ```text
  Inbound:
  사용자 -> internet-facing NLB -> private subnet의 node/pod

  Outbound:
  private subnet의 node/pod -> fck-nat -> Internet Gateway -> Internet
```

## 테스트
apply 후 아래의 명령어를 통해 Internal -IP와 Pod IP이 해당 subnet 범위에 존재하는지 확인한다.
``` bash
kubectl get nodes -o wide
kubectl get pods -A -o wide
```
아래의 명령어를 통해 EXTERNAL-IP 또는 hostname이 생기고, annotation에 internet-facing이 있으면 inbound NLB가 정상적으로 작동하는 것을 알 수 있다. 
```bash
kubectl -n ingress-nginx get svc ingress-nginx-controller -o wide
kubectl -n ingress-nginx describe svc ingress-nginx-controller
```
아래의 명령어를 통해 응답이 오면 private pod가 fck-nat를 통해 외부 인터넷으로 나가는 것을 확인할 수 있다. 
```bash
kubectl run outbound-test `
  --image=curlimages/curl `
  --rm -it --restart=Never `
  -- curl -I https://aws.amazon.com
```

## 참고
- 기존 VPC 모듈에는 fck-nat 인스턴스와 private route table의 0.0.0.0/0 -> fck-nat ENI 경로가 이미 구성되어 있기에 outbound 경로는 기존 구성을 활용하였다. => 실제로는 구성이 되어있지 않아 블랙홀이 되었다. 
- 외부 통신을 위해 vpc endpoint나 NAT를 적용한다고 하여 기존의 fck-nat를 사용하였는데, vpc endpoint나 bastion host 사용하는 방안도 시도해 봐야할 듯 하다.
