### PR TITLE
[Feat] PSS 적용 (team-b)

### DIFF
--- a/manifests/base/api/deployment.yaml
+++ b/manifests/base/api/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: api
   labels:
     app.kubernetes.io/name: api
-    training.k8rvis.io/security-baseline: insecure
+    training.k8rvis.io/security-baseline: baseline
 spec:
   replicas: 1
   selector:
@@ -14,10 +14,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: api
-        training.k8rvis.io/security-baseline: insecure
+        training.k8rvis.io/security-baseline: baseline
     spec:
       serviceAccountName: default
-      automountServiceAccountToken: true
+      automountServiceAccountToken: false
       containers:
         - name: api
           image: ealen/echo-server

--- a/manifests/base/db/statefulset.yaml
+++ b/manifests/base/db/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: db
   labels:
     app.kubernetes.io/name: db
-    training.k8rvis.io/security-baseline: insecure
+    training.k8rvis.io/security-baseline: baseline
 spec:
   serviceName: db
   replicas: 1
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: db
-        training.k8rvis.io/security-baseline: insecure
+        training.k8rvis.io/security-baseline: baseline
     spec:
       securityContext:
         fsGroup: 999
@@ -58,7 +58,7 @@ spec:
         name: redis-data
         labels:
           app.kubernetes.io/name: db
-          training.k8rvis.io/security-baseline: insecure
+          training.k8rvis.io/security-baseline: baseline
       spec:
         storageClassName: gp2
         accessModes:

--- a/manifests/base/web/deployment.yaml
+++ b/manifests/base/web/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: web
   labels:
     app.kubernetes.io/name: web
-    training.k8rvis.io/security-baseline: insecure
+    training.k8rvis.io/security-baseline: baseline
 spec:
   replicas: 1
   selector:
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: web
-        training.k8rvis.io/security-baseline: insecure
+        training.k8rvis.io/security-baseline: baseline
     spec:
       containers:
         - name: web

--- a/modules/namespaces/main.tf
+++ b/modules/namespaces/main.tf
@@ -3,16 +3,16 @@ resource "kubernetes_namespace_v1" "teams" {
 
   metadata {
     name = each.value
-    labels = merge(
-      {
-        "app.kubernetes.io/part-of" = var.project_name
-        "training.k8rvis.io/team"   = each.value
-      },
-      each.value == "team-b" ? {
-        "pod-security.kubernetes.io/enforce"         = "restricted"
-        "pod-security.kubernetes.io/enforce-version" = "latest"
-      } : {}
-    )
+    labels = {
+      "app.kubernetes.io/part-of"                  = var.project_name
+      "training.k8rvis.io/team"                    = each.value
+      "pod-security.kubernetes.io/enforce"         = "baseline"
+      "pod-security.kubernetes.io/enforce-version" = "latest"
+      "pod-security.kubernetes.io/audit"           = "baseline"
+      "pod-security.kubernetes.io/audit-version"   = "latest"
+      "pod-security.kubernetes.io/warn"            = "baseline"
+      "pod-security.kubernetes.io/warn-version"    = "latest"
+    }
   }
 }
 


### PR DESCRIPTION
## 관련 이슈
- Closes #66 

## 무엇을 만들었나요? (What)
Kubernetes Pod Security Standards(PSS) Baseline 정책을 네임스페이스에 적용해
비규격 파드가 Admission Controller 단계에서 자동 차단되도록 구성했다.
- 모든 팀 네임스페이스에 PSS Baseline 레이블(enforce/audit/warn) 기본 적용
- enforce: 비규격 파드 생성 차단 / audit: API 서버 감사 로그 기록 / warn: 경고 메시지 출력

## 왜 이렇게 만들었나요? (Why)
기존에는 네임스페이스에 PSS 레이블이 없어 Admission Controller가 파드 보안 설정을 검증하지 않았다. 개발자가 privileged 컨테이너나 hostNetwork 파드를 실수로 배포해도 클러스터가 이를 허용하는 상태였다. PSS Baseline을 적용해 비규격 파드를 생성 시점에 원천 차단한다.

## 테스트
**Step 1. PSS 레이블 적용 전 privileged 파드가 생성되는지 확인**
파드 생성 성공 → 취약

```jsx
kubectl run test-privileged --image=nginx \
  --overrides='{"spec":{"containers":[{"name":"nginx","image":"nginx","securityContext":{"privileged":true}}]}}' \
  -n team-b

```

**Step 2. Terraform apply로 네임스페이스 PSS 레이블 적용**

```jsx
terraform -chdir=environments/platform apply
```

** Step 3. 네임스페이스 레이블 확인**

```jsx
kubectl get namespace team-b --show-labels | grep pod-security
```

<img width="599" height="111" alt="image (9)" src="https://github.com/user-attachments/assets/6b351d98-8af3-485f-ab0a-8564c3680f42" />


**Step 4. Baseline 위반 파드 생성 차단 확인**
```jsx
kubectl run test-privileged --image=nginx \
--overrides='{"spec":{"containers":[{"name":"c","image":"nginx","securityContext":{"privileged":true}}]}}' \
-n <namespace>
```
<img width="592" height="238" alt="image (8)" src="https://github.com/user-attachments/assets/a556d1cf-bdbb-4c54-a4b6-5d416fb1419b" />



## 변경 사항
| 파일 | 설명 |
|------|------|
| `modules/namespaces/main.tf` | 전 팀 PSS Baseline enforce/audit/warn 레이블 추가 |
| `manifests/base/api/deployment.yaml` | security-baseline 레이블 갱신, automountServiceAccountToken false로 수정 |
| `manifests/base/web/deployment.yaml` | security-baseline 레이블 갱신 |
| `manifests/base/db/statefulset.yaml` | security-baseline 레이블 갱신 (metadata, template, volumeClaimTemplate) |

