### PR TITLE
[Feat] Namespace 기반 접근 분리 (team-b)

### DIFF
--- a/manifests/base/namespaces/kustomization.yaml
+++ b/manifests/base/namespaces/kustomization.yaml
@@ -2,8 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - runtime-secrets
-  - web
-  - api
-  - db
-  - namespaces
+  - networkpolicy.yaml

--- a/manifests/base/namespaces/networkpolicy.yaml
+++ b/manifests/base/namespaces/networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-cross-namespace-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system


### PR DESCRIPTION
## 관련 이슈
- Closes #52 

## 무엇을 만들었나요? (What)
네임스페이스 단위로 NetworkPolicy를 적용해 팀 간 파드 통신을 네트워크 레벨에서 차단한다. 같은 네임스페이스 내 파드 간 통신과 ingress-nginx, kube-system의 인바운드만 허용하고 나머지 크로스 네임스페이스 트래픽은 기본 차단된다.

## 왜 이렇게 만들었나요? (Why)
기존에는 네임스페이스가 논리적 분리만 제공했고, 네트워크 레벨에서는 다른 팀의 파드나 다른 네임스페이스 파드에 직접 접근할 수 있었다. 침해 발생 시 피해가 전체 클러스터로 확산될 위험이 있어, NetworkPolicy로 폭발 반경을 팀 네임스페이스 단위로 제한한다.
- NetworkPolicy(deny-cross-namespace-ingress): podSelector: {}로 네임스페이스 내 모든 파드에 적용
- Ingress 허용 규칙 3가지:
    1. podSelector: {} → 같은 네임스페이스 파드 간 통신 허용
    2. namespaceSelector(ingress-nginx) → 인그레스 컨트롤러 트래픽 허용
    3. namespaceSelector(kube-system) → 메트릭 수집 등 허용
- Kustomize base에 namespaces 디렉토리 추가 → 각 팀 overlay 배포 시 자동으로 해당 네임스페이스에 생성

## 테스트
### **Step 1. 취약점 파악**

임시 네임스페이스 생성 (공격자 역할)

```jsx
kubectl create namespace test-attacker
```

team-b 서비스 IP 확인(없으면 사전에 간단하게 서비스 배포 진행해야함)

```jsx
kubectl get svc -n team-b
```

공격자 네임스페이스에서 team-b 서비스로 접근 시도

```jsx
kubectl run attacker --image=curlimages/curl -n test-attacker --rm -it --restart=Never \
-- curl --max-time 5 http://<team-b-ClusterIP>
```
<img width="603" height="345" alt="image (12)" src="https://github.com/user-attachments/assets/9a8cfd72-3d23-431f-b23e-3afaedc640a8" />


### **Step 2. 적용**

```jsx
kubectl apply -k manifests/overlays/team-b
# NetworkPolicy 생성 확인
kubectl get networkpolicy -n team-b
```

### **Step 3. 적용 확인**

동일한 접근 재시도 → 차단 확인

```jsx
kubectl run attacker --image=curlimages/curl -n test-attacker --rm -it --restart=Never \
-- curl --max-time 5 http://<team-b-ClusterIP>
```
<img width="613" height="154" alt="image (11)" src="https://github.com/user-attachments/assets/2a8791bf-9310-4156-aa97-7b3e69c4babc" />


**⇒ 차단  완료**

같은 네임스페이스 내 통신은 정상 확인

```jsx
kubectl exec -n team-b <api-pod> -- curl --max-time 5 [http://db:6379](http://db:6379/)
```
<img width="611" height="359" alt="image (10)" src="https://github.com/user-attachments/assets/457b964c-2328-4772-af3a-067d0a93356c" />


테스트 네임스페이스 정리
```jsx
kubectl delete namespace test-attacker
```

## 참고
- 리뷰 시 참고할 내용, 리스크, 후속 작업이 있으면 적어주세요.
