### PR TITLE
[Feat] pod 실행 권한 최소화(team-c)

### DIFF
--- a/.github/workflows/orchestrate-environment.yml
+++ b/.github/workflows/orchestrate-environment.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   orchestrate:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME }}
@@ -45,10 +45,22 @@ jobs:
       PLATFORM_INFRA_STATE_REGION: ${{ vars.PLATFORM_INFRA_STATE_REGION }}
       ORCHESTRATION_STATE_BUCKET: ${{ vars.ORCHESTRATION_STATE_BUCKET }}
       ORCHESTRATION_STATE_KEY: ${{ vars.ORCHESTRATION_STATE_KEY }}
+      EXPECTED_RUNNER_PUBLIC_IP: 13.125.215.119
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Verify runner public IP
+        run: |
+          set -euo pipefail
+          runner_public_ip="$(curl -fsS https://checkip.amazonaws.com | tr -d '[:space:]')"
+          echo "Runner public IP: ${runner_public_ip}"
+
+          if [ "${runner_public_ip}" != "${EXPECTED_RUNNER_PUBLIC_IP}" ]; then
+            echo "::error::Runner public IP must be ${EXPECTED_RUNNER_PUBLIC_IP} to reach the EKS API endpoint."
+            exit 1
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/environments/platform/.terraform.lock.hcl
+++ b/environments/platform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
@@ -31,6 +32,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   hashes = [
     "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "h1:rsqAO9oKyDMLiysQqrWEzf9CNtU9NJtwEGk7bSItC9g=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
     "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
@@ -50,6 +52,7 @@ provider "registry.terraform.io/hashicorp/http" {
   version     = "3.5.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:MAWWGNvepa09m3Gy55OBAPk3dhCv6HnjywnKuD70ZBE=",
     "h1:dl73+8wzQR++HFGoJgDqY3mj3pm14HUuH/CekVyOj5s=",
     "zh:047c5b4920751b13425efe0d011b3a23a3be97d02d9c0e3c60985521c9c456b7",
     "zh:157866f700470207561f6d032d344916b82268ecd0cf8174fb11c0674c8d0736",
@@ -70,6 +73,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:1OF0rDUteVdoX04BrtmTc0T4NOo6+D0utmK6hM0EzZw=",
     "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - web
   - api
   - db
+  - pss-baseline.yaml

--- a/manifests/base/pss-baseline.yaml
+++ b/manifests/base/pss-baseline.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-c
+  labels:
+    pod-security.kubernetes.io/enforce: baseline # 차단
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: baseline # 경고
+    pod-security.kubernetes.io/warn-version: latest

--- a/manifests/overlays/team-c/web-deployment-patch.yaml
+++ b/manifests/overlays/team-c/web-deployment-patch.yaml
@@ -7,3 +7,29 @@ spec:
     spec:
       serviceAccountName: web-workload
       automountServiceAccountToken: false
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+
+      # 사용자 제한
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000 # 일반 사용자
+
+      containers:
+        - name: secure-container
+          image: busybox
+          command: ["sh", "-c", "sleep 1h"]
+
+          securityContext:
+            privileged: false
+
+            # Capabilities 제한
+            capabilities:
+              drop:
+                - ALL
+
+      # 호스트 경로 마운트 금지
+      volumes:
+        - name: safe-storage
+          emptyDir: {}

--- a/modules/eks/.terraform.lock.hcl
+++ b/modules/eks/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",

--- a/modules/k8s-base/.terraform.lock.hcl
+++ b/modules/k8s-base/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "~> 2.0"
   hashes = [
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "h1:rsqAO9oKyDMLiysQqrWEzf9CNtU9NJtwEGk7bSItC9g=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
     "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
     "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",


### PR DESCRIPTION
## 관련 이슈
- Closes #66 

## 무엇을 만들었나요? (What)
1. PSS Baseline 정책이 선언된 Namespace 매니페스트 추가
- team-c 에 `pod-security.kubernetes.io/enforce: baseline` 라벨을 적용하여 Admission 단계에서의 보안 검증 활성화
- enforce와 함께 warn 라벨을 병행 사용하여 배포 시 사용자에게 위반 항목을 즉시 알리도록 설정(PSA)

2. web pod yaml 구성 파일에 baseline을 위반하지 않는 설정을 적용했다. 

## 왜 이렇게 만들었나요? (Why)
- 잘못된 보안 설정이 배포될 경우, 기존에 정상 동작하던 Pod은 유지하면서 잘못된 보안 설정이 있는 web- Pod의 생성만 차단하도록 설정했다.

## 실습 과정
### step1. PSS Baseline 정책이 선언된 Namespace 매니페스트 배포 

<img width="777" height="85" alt="image (16)" src="https://github.com/user-attachments/assets/fd9b3e61-afbf-4622-9d32-0a83c2eecff1" />
(위 실습 이미지의 경우, 명령어를 통해 Baseline 정책을 'enforce(강제)' 모드로 설정했다.) 

PSS Baseline 정책이 선언된 Namespace 매니페스트도 생성 후 배포하여 테스트를 동일하게 진행했다. 네임스페이스의 보안 수준을 코드로 정의하고 형상 관리가 가능하도록 구성했다.

### step2. 취약한 설정 주입 테스트 

1. hostNetwork: false / hostPID: false/ hostIPC: false -컨테이너는 기본적으로 호스트와 분리된 독립적인 네트워크 공간, 프로세스 목록, 통신 채널을 가져야하는데, false일 경우 분리되지 않게 한다.
2. privileged: true - 컨테이너 안의 사용자에게 호스트의 루트(root)와 다름없는 전권을 주는 것
3. hostPath: path: /etc - 컨테이너가 서버 호스트의 특정 폴더를 내 방처럼 드나들지 못하게 제한
취약한 설정을 포함한 yaml을 배포하면 아래와 같은 warning 메세지를 볼 수 있다.

<img width="786" height="398" alt="image (17)" src="https://github.com/user-attachments/assets/db3fda6b-9dd4-4b53-81bb-940c6253a5c2" />

kubectl get pods -n [네임스페이스명] 입력했을 때 web pod가 아예 생성되지 않은 것을 확인할 수 있다.

<img width="763" height="102" alt="image (18)" src="https://github.com/user-attachments/assets/59089029-55c2-4d45-b86a-446b0be4d9c4" />

안전한 설정으로 변경 후 재배포하면 다음과 같다.
 
<img width="762" height="132" alt="image (19)" src="https://github.com/user-attachments/assets/b54a480b-8ce1-4ff2-b4a9-ec632b2c3463" />


## 참고
- 이전 quickwins 실습에서 진행한 readOnlyRootFilesystem:true, runAsNonRoot:true,allowPrivilegeEscalation:false 까지 더해지면 PSS의 restricted를 만족하게 된다. 

<img width="682" height="437" alt="image" src="https://github.com/user-attachments/assets/d50151a6-c33c-4c3e-aaf0-6d171a1fd7ff" />

-privileged, hostNetwork, hostPID, hostIPC 등은 명시하지 않으면 쿠버네티스가 자동으로 false로 처리하기 때문에 baseline 에 위반되지 않게된다. 하지만 이번 실습에선 명시하였다.