### PR TITLE
[Feat] Kubernetes API endpoint를 private-only 전환 (team-a)

### DIFF
--- a/environments/infra/main.tf
+++ b/environments/infra/main.tf
@@ -16,14 +16,16 @@ module "vpc" {
 module "eks" {
   source = "../../modules/eks"
 
-  project_name                = var.project_name
-  environment                 = var.environment
-  owner                       = var.owner
-  cluster_subnet_ids          = module.vpc.private_subnet_ids
-  node_subnet_ids             = module.vpc.public_subnet_ids
-  cluster_public_access_cidrs = var.cluster_public_access_cidrs
-  kubernetes_version          = var.kubernetes_version
-  node_ami_type               = var.node_ami_type
-  node_group                  = var.node_group
-  default_tags                = var.default_tags
+  project_name                    = var.project_name
+  environment                     = var.environment
+  owner                           = var.owner
+  cluster_subnet_ids              = module.vpc.private_subnet_ids
+  node_subnet_ids                 = module.vpc.public_subnet_ids
+  cluster_endpoint_private_access = var.cluster_endpoint_private_access
+  cluster_endpoint_public_access  = var.cluster_endpoint_public_access
+  cluster_public_access_cidrs     = var.cluster_public_access_cidrs
+  kubernetes_version              = var.kubernetes_version
+  node_ami_type                   = var.node_ami_type
+  node_group                      = var.node_group
+  default_tags                    = var.default_tags
 }

--- a/environments/infra/outputs.tf
+++ b/environments/infra/outputs.tf
@@ -53,6 +53,16 @@ output "cluster_security_group_id" {
   value       = module.eks.cluster_security_group_id
 }
 
+output "vpn_private_api_access_enabled" {
+  description = "Whether VPN/self-hosted runner private API access resources are enabled."
+  value       = var.enable_vpn_private_api_access
+}
+
+output "vpn_to_eks_peering_connection_id" {
+  description = "VPC peering connection ID between the VPN/self-hosted runner VPC and the EKS VPC."
+  value       = var.enable_vpn_private_api_access ? aws_vpc_peering_connection.vpn_to_eks[0].id : null
+}
+
 output "node_group_name" {
   description = "Name of the default infra EKS managed node group."
   value       = module.eks.node_group_name

--- a/environments/infra/terraform.tfvars
+++ b/environments/infra/terraform.tfvars
@@ -21,11 +21,9 @@ private_subnet_cidrs = [
 ]
 
 cluster_endpoint_private_access = true
-cluster_endpoint_public_access = false
+cluster_endpoint_public_access  = false
 
-cluster_public_access_cidrs = [
-  "13.125.215.119/32",
-]
+cluster_public_access_cidrs = []
 
 enable_vpn_private_api_access = true
 

--- a/environments/infra/terraform.tfvars
+++ b/environments/infra/terraform.tfvars
@@ -20,8 +20,20 @@ private_subnet_cidrs = [
   "10.0.20.0/24",
 ]
 
+cluster_endpoint_private_access = true
+cluster_endpoint_public_access = false
+
 cluster_public_access_cidrs = [
   "13.125.215.119/32",
+]
+
+enable_vpn_private_api_access = true
+
+vpn_vpc_id   = "vpc-096c2102f9e82e7e2"
+vpn_vpc_cidr = "172.31.0.0/16"
+
+vpn_route_table_ids = [
+  "rtb-0557e212d043259bf",
 ]
 
 fck_nat_instance_type = "t4g.nano"

--- a/environments/infra/variables.tf
+++ b/environments/infra/variables.tf
@@ -41,6 +41,19 @@ variable "private_subnet_cidrs" {
 variable "cluster_public_access_cidrs" {
   description = "CIDR blocks allowed to access the infra EKS public API endpoint."
   type        = list(string)
+  default     = []
+}
+
+variable "cluster_endpoint_private_access" {
+  description = "Whether the infra EKS private API endpoint is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_endpoint_public_access" {
+  description = "Whether the infra EKS public API endpoint is enabled."
+  type        = bool
+  default     = false
 }
 
 variable "fck_nat_instance_type" {
@@ -84,4 +97,28 @@ variable "node_group" {
     max_size       = 4
     disk_size_gb   = 20
   }
+}
+
+variable "enable_vpn_private_api_access" {
+  description = "Whether to connect the VPN/self-hosted runner VPC to the EKS private API endpoint."
+  type        = bool
+  default     = false
+}
+
+variable "vpn_vpc_id" {
+  description = "VPC ID where the VPN/self-hosted runner is running."
+  type        = string
+  default     = null
+}
+
+variable "vpn_vpc_cidr" {
+  description = "CIDR block of the VPN/self-hosted runner VPC."
+  type        = string
+  default     = null
+}
+
+variable "vpn_route_table_ids" {
+  description = "Route table IDs used by the VPN/self-hosted runner subnets."
+  type        = list(string)
+  default     = []
 }

--- a/environments/infra/vpn-private-api-access.tf
+++ b/environments/infra/vpn-private-api-access.tf
@@ -1,0 +1,79 @@
+locals {
+  vpn_route_table_ids = var.enable_vpn_private_api_access ? toset(var.vpn_route_table_ids) : toset([])
+}
+
+resource "aws_vpc_peering_connection" "vpn_to_eks" {
+  count = var.enable_vpn_private_api_access ? 1 : 0
+
+  vpc_id      = var.vpn_vpc_id
+  peer_vpc_id = module.vpc.vpc_id
+  auto_accept = true
+
+  tags = merge(
+    var.default_tags,
+    {
+      Name        = "${var.project_name}-${var.environment}-vpn-to-eks"
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Purpose     = "eks-private-api-access"
+    }
+  )
+
+  lifecycle {
+    precondition {
+      condition     = var.vpn_vpc_id != null && var.vpn_vpc_id != ""
+      error_message = "vpn_vpc_id must be set when VPN private API access is enabled."
+    }
+
+    precondition {
+      condition     = var.vpn_vpc_cidr != null && var.vpn_vpc_cidr != ""
+      error_message = "vpn_vpc_cidr must be set when VPN private API access is enabled."
+    }
+
+    precondition {
+      condition     = length(var.vpn_route_table_ids) > 0
+      error_message = "At least one VPN route table ID must be set when VPN private API access is enabled."
+    }
+  }
+}
+
+resource "aws_vpc_peering_connection_options" "vpn_to_eks" {
+  count = var.enable_vpn_private_api_access ? 1 : 0
+
+  vpc_peering_connection_id = aws_vpc_peering_connection.vpn_to_eks[0].id
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
+resource "aws_route" "vpn_to_eks" {
+  for_each = local.vpn_route_table_ids
+
+  route_table_id            = each.value
+  destination_cidr_block    = module.vpc.vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.vpn_to_eks[0].id
+}
+
+resource "aws_route" "eks_private_to_vpn" {
+  count = var.enable_vpn_private_api_access ? 1 : 0
+
+  route_table_id            = module.vpc.private_route_table_id
+  destination_cidr_block    = var.vpn_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.vpn_to_eks[0].id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_vpn_to_eks_private_api" {
+  count = var.enable_vpn_private_api_access ? 1 : 0
+
+  security_group_id = module.eks.cluster_security_group_id
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_ipv4         = var.vpn_vpc_cidr
+  description       = "Allow VPN/self-hosted runner VPC to access the EKS private API endpoint"
+}

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -107,9 +107,21 @@ resource "aws_eks_cluster" "this" {
 
   vpc_config {
     subnet_ids              = var.cluster_subnet_ids
-    endpoint_private_access = true
-    endpoint_public_access  = true
-    public_access_cidrs     = var.cluster_public_access_cidrs
+    endpoint_private_access = var.cluster_endpoint_private_access
+    endpoint_public_access  = var.cluster_endpoint_public_access
+    public_access_cidrs     = var.cluster_endpoint_public_access ? var.cluster_public_access_cidrs : null
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.cluster_endpoint_private_access || var.cluster_endpoint_public_access
+      error_message = "At least one EKS API endpoint access mode must be enabled."
+    }
+
+    precondition {
+      condition     = !var.cluster_endpoint_public_access || length(var.cluster_public_access_cidrs) > 0
+      error_message = "Public endpoint access requires at least one public access CIDR."
+    }
   }
 
   depends_on = [

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -33,14 +33,22 @@ variable "node_subnet_ids" {
   }
 }
 
-variable "cluster_public_access_cidrs" {
-  description = "CIDR blocks allowed to access the EKS public API endpoint."
-  type        = list(string)
+variable "cluster_endpoint_private_access" {
+  description = "Whether the EKS private API endpoint is enabled."
+  type        = bool
+  default     = true
+}
 
-  validation {
-    condition     = length(var.cluster_public_access_cidrs) > 0
-    error_message = "At least one CIDR must be supplied for the EKS public API endpoint."
-  }
+variable "cluster_endpoint_public_access" {
+  description = "Whether the EKS public API endpoint is enabled."
+  type        = bool
+  default     = false
+}
+
+variable "cluster_public_access_cidrs" {
+  description = "CIDR blocks allowed to access the EKS public API endpoint when public access is enabled."
+  type        = list(string)
+  default     = []
 
   validation {
     condition     = !contains(var.cluster_public_access_cidrs, "0.0.0.0/0") && !contains(var.cluster_public_access_cidrs, "::/0")


### PR DESCRIPTION
## 관련 이슈
- Closes #67

## 무엇을 만들었나요? (What)
- EKS Cluster API endpoint를 private-only로 설정하였다. 
- VPN/self-hosted runner VPC에서 EKS private API endpoint에 접근할 수 있도록 infra 코드에 리소스를 추가하였다. 
  - VPC Peering
  - Peering DNS resolution option
  - EKS cluster security group TCP 443 ingress rule
- 최종 private-only 상태 기준으로 `cluster_endpoint_public_access = false`, `cluster_public_access_cidrs = []`를 적용하였다.

## 왜 이렇게 만들었나요? (Why)
- EKS API Server의 public endpoint를 비활성화하여 인터넷에서 Kubernetes API에 직접 도달할 수 있는 경로를 제거하기 위해서이다.
- private-only 전환 후에도 운영자와 self-hosted runner가 VPN VPC 경로를 통해 EKS API에 접근할 수 있도록 구성하였다.
- CLI를 이용하여 만든 Peering/route/SG 규칙은 Terraform state에 남지 않아 destroy 시 dependency 문제가 발생할 수 있으므로, 관련 네트워크 구성을 코드로 관리하도록 변경하였다.
- `cluster_public_access_cidrs` 변수는 롤백 가능성을 위해 유지하되, private-only 최종 상태에서는 빈 리스트로 설정하였다.

## 테스트
- [ ] EKS endpoint 설정이 `endpointPrivateAccess=true`, `endpointPublicAccess=false`로 적용되는지 확인
- [ ] VPN 연결 상태에서 클러스터 접근 가능 여부 확인
<br>
<img width="847" height="486" alt="image" src="https://github.com/user-attachments/assets/3a3ef639-0d52-4bd2-84e3-b986319c3523" />
각각 VPN 연결했을 때와 하지 않았을 때로 네트워크 연결 가능 여부를 확인할 수 있다.
<br>

<img width="853" height="234" alt="image" src="https://github.com/user-attachments/assets/83e6a170-db71-4079-9a38-51fc17a7efd8" />
위의 두 경우는 VPN을 연결하였을 때이고, 아래 두 경우는 연결하지 않았을 때로 각각 kubectl 접근 여부를 확인하였다. 

## 참고
- 기존 VPN VPC에 EKS VPC로 향하는 route와 Peering 연결만 추가하였다.
- self-hosted runner가 사용하는 subnet의 route table이 바뀌면 `vpn_route_table_ids` 값을 함께 갱신해야 한다.

