### PR TITLE
aws_eks_addon.vpc_cni 삭제

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -210,7 +210,7 @@ resource "aws_eks_node_group" "this" {
   }
 
   depends_on = [
-    aws_eks_addon.vpc_cni,
+    # aws_eks_addon.vpc_cni,
     aws_iam_role_policy_attachment.node_worker_policy,
     aws_iam_role_policy_attachment.node_cni_policy,
     aws_iam_role_policy_attachment.node_ecr_policy,


### PR DESCRIPTION
<img width="840" height="227" alt="image" src="https://github.com/user-attachments/assets/5726894a-5d23-4980-ac4e-67528600652b" />

더이상 사용하지 않는 cni addon을 depends on 에서 삭제