### PR TITLE
map 방식으로 변경

### DIFF
--- a/modules/vpc-peering/main.tf
+++ b/modules/vpc-peering/main.tf
@@ -48,7 +48,9 @@ resource "aws_vpc_peering_connection_options" "this" {
 }
 
 resource "aws_route" "requester_to_accepter" {
-  for_each = toset(var.requester_route_table_ids)
+  for_each = {
+    for idx, route_table_id in var.requester_route_table_ids : idx => route_table_id
+  }
 
   route_table_id            = each.value
   destination_cidr_block    = var.accepter_vpc_cidr
@@ -56,7 +58,9 @@ resource "aws_route" "requester_to_accepter" {
 }
 
 resource "aws_route" "accepter_to_requester" {
-  for_each = toset(var.accepter_route_table_ids)
+  for_each = {
+    for idx, route_table_id in var.accepter_route_table_ids : idx => route_table_id
+  }
 
   route_table_id            = each.value
   destination_cidr_block    = var.requester_vpc_cidr


### PR DESCRIPTION
module.vpc.private_route_table_id는 VPC 모듈이 apply 되기 전까지 실제 ID가 확정되지 않는다. 그런데 toset(...)을 쓰면 Terraform이 그 ID 값을 for_each의 리소스 키로 사용해야 해서, plan 단계에서 키를 만들 수 없어 오류가 나게된다.

따라서 toset(...) 대신 인덱스를 키로 쓰는 map으로 변경한다.