### PR TITLE
access entry 로직 일부 수정

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -108,7 +108,7 @@ resource "aws_eks_cluster" "this" {
   access_config {
     authentication_mode = var.authentication_mode
   }
-  
+
   vpc_config {
     subnet_ids              = var.cluster_subnet_ids
     endpoint_private_access = true
@@ -248,9 +248,9 @@ resource "aws_eks_addon" "ebs_csi_driver" {
 resource "aws_eks_access_entry" "this" {
   for_each = var.access_entries
 
-  cluster_name      = aws_eks_cluster.this.name
-  principal_arn     = each.value.principal_arn
-  type              = "STANDARD"
+  cluster_name  = aws_eks_cluster.this.name
+  principal_arn = each.value.principal_arn
+  type          = "STANDARD"
   depends_on = [
     aws_eks_cluster.this
   ]

--- a/scripts/manage_environment.py
+++ b/scripts/manage_environment.py
@@ -141,9 +141,10 @@ class TerraformRunner:
 
 
 class EnvironmentOrchestrator:
-    def __init__(self, state_store: Any, terraform_runner: Any):
+    def __init__(self, state_store: Any, terraform_runner: Any, refresh_infra_on_start: bool = False):
         self.state_store = state_store
         self.terraform_runner = terraform_runner
+        self.refresh_infra_on_start = refresh_infra_on_start
 
     def run(self, operation: str, slack_user_id: str, namespace: str, request_id: str) -> dict[str, Any]:
         current_state = self._normalize_state(self.state_store.read_state())
@@ -196,7 +197,11 @@ class EnvironmentOrchestrator:
         next_state["active_users"][slack_user_id] = namespace
         next_state["active_namespaces"] = sorted(set(next_state["active_users"].values()))
 
-        should_apply_infra = current_state.get("infra_status") != "running" or not current_state["active_users"]
+        should_apply_infra = (
+            current_state.get("infra_status") != "running"
+            or not current_state["active_users"]
+            or self.refresh_infra_on_start
+        )
         if should_apply_infra:
             self.terraform_runner.apply_infra()
 
@@ -259,6 +264,7 @@ def main() -> None:
     orchestrator = EnvironmentOrchestrator(
         state_store=build_state_store_from_env(),
         terraform_runner=build_runner_from_env(),
+        refresh_infra_on_start=bool(os.environ.get("TF_VAR_user_iam_arn", "").strip()),
     )
     result = orchestrator.run(
         operation=args.operation,

--- a/tests/test_manage_environment.py
+++ b/tests/test_manage_environment.py
@@ -101,6 +101,38 @@ class OrchestratorTests(unittest.TestCase):
         self.assertEqual(result["active_users"], {"U123": "team-a", "U456": "team-b"})
         self.assertEqual(result["active_namespaces"], ["team-a", "team-b"])
 
+    def test_start_refreshes_infra_before_platform_when_requested(self):
+        module = load_module()
+        initial_state = module.default_state()
+        initial_state.update(
+            {
+                "infra_status": "running",
+                "active_users": {"U123": "team-a"},
+                "active_namespaces": ["team-a"],
+            }
+        )
+        state_store = FakeStateStore(initial_state)
+        terraform_runner = RecordingTerraformRunner()
+        orchestrator = module.EnvironmentOrchestrator(
+            state_store=state_store,
+            terraform_runner=terraform_runner,
+            refresh_infra_on_start=True,
+        )
+
+        result = orchestrator.run(
+            operation="start",
+            slack_user_id="U456",
+            namespace="team-b",
+            request_id="req-2-refresh",
+        )
+
+        self.assertEqual(
+            terraform_runner.calls,
+            [("apply_infra", None), ("apply_platform", ["team-a", "team-b"])],
+        )
+        self.assertEqual(result["active_users"], {"U123": "team-a", "U456": "team-b"})
+        self.assertEqual(result["active_namespaces"], ["team-a", "team-b"])
+
     def test_stop_with_remaining_users_reapplies_platform_subset(self):
         module = load_module()
         initial_state = module.default_state()


### PR DESCRIPTION
확인해보니 access entry 코드 자체는 들어가 있습니다. 다만 원인으로 보이는 부분이 하나 있었습니다.

현재 봇 스크립트는 infra가 이미 `running` 상태라고 판단하면 `environments/infra`의 `terraform apply`를 생략하고 바로 platform apply로 넘어갑니다. 그래서 GitHub Secret을 나중에 등록해도, access entry를 만드는 infra apply가 실행되지 않아 `kubernetes_service_account` 단계에서 `Unauthorized`가 날 수 있습니다.

- scripts/manage_environment.py`TF_VAR_user_iam_arn`이 있으면 start 시 infra apply를 먼저 다시 수행하도록 변경했습니다.