### PR TITLE
[Feature] Security Metric 수집 및 Runtime 시각화 구축(Stage 3)

### DIFF
--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -136,6 +136,9 @@ module "k8s_base" {
   external_secrets_namespace                        = var.external_secrets_namespace
   external_secrets_chart_version                    = var.external_secrets_chart_version
   external_secrets_service_account_name             = var.external_secrets_service_account_name
+  prometheus_namespace                              = var.prometheus_namespace
+  prometheus_chart_version                          = var.prometheus_chart_version
+  grafana_admin_password                            = var.grafana_admin_password
 
   depends_on = [
     aws_eks_pod_identity_association.aws_load_balancer_controller,

--- a/environments/platform/terraform.tfvars
+++ b/environments/platform/terraform.tfvars
@@ -13,3 +13,7 @@ aws_load_balancer_controller_chart_version = "3.2.2"
 argocd_chart_version                       = "9.4.17"
 argocd_apps_chart_version                  = "2.0.3"
 gitops_repo_url                            = "https://github.com/K8RVIS/eks-secure-infra.git"
+
+prometheus_chart_version = "70.4.2"
+# grafana_admin_password은 tfvars에 직접 넣지 않는다.
+# 배포 시 환경변수로 주입한다: export TF_VAR_grafana_admin_password=<password>

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -172,3 +172,21 @@ variable "team_names" {
   type        = list(string)
   default     = ["team-a", "team-b", "team-c", "team-d"]
 }
+
+variable "prometheus_namespace" {
+  description = "Namespace used for the kube-prometheus-stack release."
+  type        = string
+  default     = "monitoring"
+}
+
+variable "prometheus_chart_version" {
+  description = "Pinned chart version for kube-prometheus-stack."
+  type        = string
+  default     = "70.4.2"
+}
+
+variable "grafana_admin_password" {
+  description = "Grafana admin password. Set via tfvars or TF_VAR_grafana_admin_password."
+  type        = string
+  sensitive   = true
+}

--- a/modules/k8s-base/dashboards/security-overview.json
+++ b/modules/k8s-base/dashboards/security-overview.json
@@ -1,0 +1,144 @@
+{
+  "title": "EKS Security Overview",
+  "uid": "eks-security-overview",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "API Server 4xx 요청 rate (5m)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(apiserver_request_total{code=~\"4..\"}[5m])) by (code, verb)",
+          "legendFormat": "{{code}} {{verb}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "API Server 요청 rate (verb별)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(apiserver_request_total[5m])) by (verb)",
+          "legendFormat": "{{verb}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 3,
+      "title": "네임스페이스별 Pod 재시작 (1h)",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(increase(kube_pod_container_status_restarts_total[1h])) by (namespace, pod) > 0",
+          "legendFormat": "",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "renameByName": { "namespace": "네임스페이스", "pod": "Pod", "Value": "재시작 횟수" } } }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Pending Pod 수 (네임스페이스별)",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(kube_pod_status_phase{phase=\"Pending\"}) by (namespace)",
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "ResourceQuota CPU 사용률",
+      "type": "gauge",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "kube_resourcequota{resource=\"requests.cpu\", type=\"used\"} / kube_resourcequota{resource=\"requests.cpu\", type=\"hard\"}",
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "ResourceQuota Memory 사용률",
+      "type": "gauge",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "kube_resourcequota{resource=\"requests.memory\", type=\"used\"} / kube_resourcequota{resource=\"requests.memory\", type=\"hard\"}",
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -147,3 +147,92 @@ resource "helm_release" "external_secrets" {
 
   depends_on = [helm_release.aws_load_balancer_controller]
 }
+
+# ---------------------------------------------------------------------------
+# kube-prometheus-stack
+#   Prometheus + Grafana + kube-state-metrics + node-exporter 를 한 번에 배포.
+#   Grafana sidecar가 grafana_dashboard: "1" 레이블이 붙은 ConfigMap을 자동 감지한다.
+# ---------------------------------------------------------------------------
+resource "helm_release" "kube_prometheus_stack" {
+  name             = "kube-prometheus-stack"
+  namespace        = var.prometheus_namespace
+  create_namespace = true
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "kube-prometheus-stack"
+  version          = var.prometheus_chart_version
+  timeout          = var.helm_release_timeout_seconds
+  atomic           = true
+  cleanup_on_fail  = true
+  wait             = true
+
+  values = [
+    yamlencode({
+      prometheus = {
+        prometheusSpec = {
+          retention = "7d"
+          resources = {
+            requests = { cpu = "250m", memory = "512Mi" }
+            limits   = { cpu = "500m", memory = "1Gi" }
+          }
+          storageSpec = {
+            volumeClaimTemplate = {
+              spec = {
+                storageClassName = kubernetes_storage_class_v1.encrypted_gp3.metadata[0].name
+                accessModes      = ["ReadWriteOnce"]
+                resources        = { requests = { storage = "20Gi" } }
+              }
+            }
+          }
+        }
+      }
+      grafana = {
+        adminPassword = var.grafana_admin_password
+        persistence = {
+          enabled          = true
+          storageClassName = kubernetes_storage_class_v1.encrypted_gp3.metadata[0].name
+          size             = "5Gi"
+        }
+        sidecar = {
+          dashboards = {
+            enabled         = true
+            label           = "grafana_dashboard"
+            searchNamespace = "ALL"
+          }
+        }
+        ingress = {
+          enabled          = true
+          ingressClassName = "nginx"
+          hosts            = ["grafana.${var.cluster_name}.local"]
+        }
+      }
+      alertmanager = {
+        enabled = false
+      }
+    })
+  ]
+
+  depends_on = [
+    helm_release.ingress_nginx,
+    kubernetes_storage_class_v1.encrypted_gp3,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Grafana 보안 대시보드 ConfigMap
+#   Grafana sidecar가 이 ConfigMap을 자동으로 감지해 대시보드를 등록한다.
+# ---------------------------------------------------------------------------
+resource "kubernetes_config_map" "grafana_security_dashboard" {
+  metadata {
+    name      = "grafana-security-dashboard"
+    namespace = var.prometheus_namespace
+    labels = {
+      grafana_dashboard = "1"
+    }
+  }
+
+  data = {
+    "security-overview.json" = file("${path.module}/dashboards/security-overview.json")
+  }
+
+  depends_on = [helm_release.kube_prometheus_stack]
+}

--- a/modules/k8s-base/outputs.tf
+++ b/modules/k8s-base/outputs.tf
@@ -47,3 +47,13 @@ output "encrypted_storage_class_name" {
   description = "Encrypted gp3 StorageClass name for EBS-backed workload PVCs."
   value       = kubernetes_storage_class_v1.encrypted_gp3.metadata[0].name
 }
+
+output "prometheus_release_name" {
+  description = "Helm release name for kube-prometheus-stack."
+  value       = helm_release.kube_prometheus_stack.name
+}
+
+output "prometheus_namespace" {
+  description = "Namespace where kube-prometheus-stack is deployed."
+  value       = helm_release.kube_prometheus_stack.namespace
+}

--- a/modules/k8s-base/variables.tf
+++ b/modules/k8s-base/variables.tf
@@ -96,3 +96,21 @@ variable "external_secrets_service_account_name" {
   type        = string
   default     = "external-secrets"
 }
+
+variable "prometheus_namespace" {
+  description = "Namespace used for the kube-prometheus-stack release."
+  type        = string
+  default     = "monitoring"
+}
+
+variable "prometheus_chart_version" {
+  description = "Pinned chart version for kube-prometheus-stack."
+  type        = string
+  default     = "70.4.2"
+}
+
+variable "grafana_admin_password" {
+  description = "Grafana admin password. Set via tfvars or environment variable (TF_VAR_grafana_admin_password)."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #49 

## 무엇을 만들었나요? (What)
kube-prometheus-stack Helm chart를 modules/k8s-base에 추가해 Prometheus + Grafana 를 한 번에 배포한다. Grafana에는 EKS 보안 지표를 한눈에 파악할 수 있는 Security Overview 대시보드를 함께 구성했다.

## 왜 이렇게 만들었나요? (Why)
kube-prometheus-stack은 Prometheus, Grafana, kube-state-metrics, node-exporter를 하나의 Helm chart로 묶어 제공한다. 각 컴포넌트를 개별 chart로 설치하면 버전 호환성 관리와 설정 연동을 직접 해야 하지만, kube-prometheus-stack은 이를 단일 values로 통합 관리하므로 운영 복잡도를 낮출 수 있다.
기존 k8s-base 모듈에 Helm release를 추가한 이유는 두 가지이다. 첫번째는 이미 배포된 ingress-nginx를 Grafana의 ingressClassName으로 재사용해 별도 LB 없이 대시보드에 접근할 수 있다. 두번째는 encrypted-gp3 StorageClass를 Prometheus의 영구 스토리지로 사용해 메트릭 데이터가 암호화된 EBS 볼륨에 저장되도록 했다.
특히나 Grafana 대시보드 등록 방식으로 sidecar + ConfigMap을 선택한 이유는 GitOps 흐름과 일치하기 때문이다. 대시보드를 Grafana UI에서 직접 만들면 재배포 시 초기화되지만, ConfigMap에 JSON을 담아 grafana_dashboard: "1" 레이블을 붙이면 sidecar가 자동 감지해 영구 반영된다고 해서 이 방법을 선택했다. 대시보드 JSON을 dashboards/security-overview.json으로 별도 파일로 분리한 것은 main.tf 가독성을 유지하면서 패널을 추가하거나 수정 시에 JSON만 편집할 수 있도록 하기 위함이다.
grafana_admin_password는 tfvars에 넣지 않고 TF_VAR_grafana_admin_password 환경변수로 주입하도록 했다. 비밀번호가 git 이력에 남는 것을 막기 위함이며, 변수에 sensitive = true를 설정해 terraform plan/apply 출력에도 노출되지 않도록 했다.

## 변경 내용
| 파일 | 변경 내용 |
|------|-----------|
| `modules/k8s-base/main.tf` | kube-prometheus-stack Helm release 추가, 대시보드 ConfigMap 추가 |
| `modules/k8s-base/variables.tf` | `prometheus_namespace`, `prometheus_chart_version`, `grafana_admin_password` 변수 추가 |
| `modules/k8s-base/outputs.tf` | `prometheus_release_name`, `prometheus_namespace` output 추가 |
| `modules/k8s-base/dashboards/security-overview.json` | Grafana Security Overview 대시보드 신규 생성 |
| `environments/platform/main.tf` | k8s_base 모듈에 Prometheus 변수 전달 |
| `environments/platform/variables.tf` | Prometheus 관련 변수 추가 |
| `environments/platform/terraform.tfvars` | `prometheus_chart_version` 기본값 설정 |

## 대시보드 구성 패널
- API Server 4xx 요청 rate : `apiserver_request_total{code=~"4.."}`  ⇒ 5m rate > 5 req/s 시 경고
- API Server 요청 rate (verb별)  : `apiserver_request_total by verb` ⇒ 비정상 verb 급증 감지
- 네임스페이스별 Pod 재시작  : `kube_pod_container_status_restarts_total` ⇒ 1h 내 재시작 발생 Pod
- Pending Pod 수  :  `kube_pod_status_phase{phase="Pending"}` ⇒ 네임스페이스당 3개 이상 시 red
- ResourceQuota CPU/Memory 사용률  : `kube_resourcequota` ⇒ 90% 이상 시 red

※ RoleBinding 변경, kubectl exec, privileged Pod 생성 이벤트는 Prometheus로 수집 불가 (Kubernetes Audit Log 필요). 해당 항목은 별도 이슈로 분리!

## 테스트

**Step 1. 취약점 파악**
`kubectl get pods -n monitoring` 실행 시 네임스페이스 자체가 없어 보안 지표 실시간 파악 불가 상태 확인상태거나 4xx 이벤트가 발생해도 추적 불가 상태다. 
⇒ no  ← 거부됐는데 언제, 누가, 몇 번 시도했는지 알 수 없음

<img width="712" height="143" alt="image (15)" src="https://github.com/user-attachments/assets/33df48c5-4115-491f-8cee-f609e5ae50ea" />


**Step 2. 적용**

```jsx
export TF_VAR_grafana_admin_password=<각자 원하는 비밀번호 설정>

export AWS_PROFILE=team-b
export AWS_REGION=ap-northeast-2
terraform init && terraform apply
```

- 적용 확인

```jsx
kubectl get pods -n monitoring
kubectl port-forward svc/kube-prometheus-stack-grafana 3000:80 -n monitoring
```
<img width="1911" height="685" alt="image (16)" src="https://github.com/user-attachments/assets/d5273d50-3a38-410d-bd5d-242fc629cc8f" />
<img width="942" height="905" alt="image (17)" src="https://github.com/user-attachments/assets/4aa0d83d-706e-45c9-aa88-df5c079b6eb4" />


→ 접속 잘된다!

localhost:3000 접속 후 Security Overview 대시보드 확인. 아래 명령으로 이벤트 유도 후 패널 반영 확인. 

**Pod 재시작 패널 검증**

```jsx
kubectl exec -n <namespace> <pod-name> -- sh -c "kill 1"

```
<img width="955" height="280" alt="image (18)" src="https://github.com/user-attachments/assets/09b80698-5be7-4976-a6c5-0e009008c773" />

⇒ 컨테이너 프로세스 강제 종료 → CrashLoopBackOff → 패널에 재시작 횟수 상승 확인

강제로 크래시 시킴 컨테이너가 죽고 Kubernetes가 재시작하면서 카운터가 올라간다

**Pending Pod 패널 검증**

```jsx
kubectl apply -f - <<'EOF'
apiVersion: v1
kind: Pod
metadata:
  name: pending-test
  namespace: team-b
spec:
  nodeSelector:
    non-existent-label: "true"
  containers:
  - name: pending-test
    image: nginx:alpine
    resources:
      requests:
        cpu: "100m"
        memory: "128Mi"
      limits:
        cpu: "200m"
        memory: "128Mi"
EOF

```
<img width="955" height="907" alt="image (19)" src="https://github.com/user-attachments/assets/02f96a84-2866-464f-ab00-751007b7658f" />

→ 존재하지 않는 노드 조건으로 스케줄링 불가 → Pending 상태 유지 → 패널에 `team-b: 1` 확인

## 참고
Stage 1. #123
Stage 2. #124
Stage 3. #107
Stage 4. #125

## 참고 자료
- https://prometheus-operator.dev/docs/getting-started/introduction/
- https://grafana.com/docs/grafana/latest/administration/provisioning/
- https://docs.aws.amazon.com/eks/latest/best-practices/control-plane.html

kube-prometheus-stack values 옵션이 엄청 많아서 공식 chart repo 보면서 작업

- https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack

Grafana sidecar가 ConfigMap 어떻게 감지하는지는 여기서 확인

- https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards

대시보드에서 쓴 메트릭들 스펙 확인용

- https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/workload/pod-metrics.md
- https://kubernetes.io/docs/reference/instrumentation/metrics/

terraform sensitive 변수 처리 방삭

- https://developer.hashicorp.com/terraform/language/values/variables#suppressing-values-in-cli-output
