### PR TITLE
[Feat] AlertManager 및 보안 알림 규칙 추가

### DIFF
--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -136,6 +136,9 @@ module "k8s_base" {
   external_secrets_namespace                        = var.external_secrets_namespace
   external_secrets_chart_version                    = var.external_secrets_chart_version
   external_secrets_service_account_name             = var.external_secrets_service_account_name
+  prometheus_namespace                              = var.prometheus_namespace
+  prometheus_chart_version                          = var.prometheus_chart_version
+  grafana_admin_password                            = var.grafana_admin_password
 
   depends_on = [
     aws_eks_pod_identity_association.aws_load_balancer_controller,

--- a/environments/platform/terraform.tfvars
+++ b/environments/platform/terraform.tfvars
@@ -13,3 +13,7 @@ aws_load_balancer_controller_chart_version = "3.2.2"
 argocd_chart_version                       = "9.4.17"
 argocd_apps_chart_version                  = "2.0.3"
 gitops_repo_url                            = "https://github.com/K8RVIS/eks-secure-infra.git"
+
+prometheus_chart_version = "70.4.2"
+# grafana_admin_password은 tfvars에 직접 넣지 않는다.
+# 배포 시 환경변수로 주입한다: export TF_VAR_grafana_admin_password=<password>

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -172,3 +172,21 @@ variable "team_names" {
   type        = list(string)
   default     = ["team-a", "team-b", "team-c", "team-d"]
 }
+
+variable "prometheus_namespace" {
+  description = "Namespace used for the kube-prometheus-stack release."
+  type        = string
+  default     = "monitoring"
+}
+
+variable "prometheus_chart_version" {
+  description = "Pinned chart version for kube-prometheus-stack."
+  type        = string
+  default     = "70.4.2"
+}
+
+variable "grafana_admin_password" {
+  description = "Grafana admin password. Set via tfvars or TF_VAR_grafana_admin_password."
+  type        = string
+  sensitive   = true
+}

--- a/modules/k8s-base/alert-rules.tf
+++ b/modules/k8s-base/alert-rules.tf
@@ -1,0 +1,74 @@
+resource "kubernetes_manifest" "security_alert_rules" {
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "PrometheusRule"
+    metadata = {
+      name      = "eks-security-alerts"
+      namespace = var.prometheus_namespace
+      labels = {
+        release = "kube-prometheus-stack"
+      }
+    }
+    spec = {
+      groups = [
+        {
+          name = "eks-security"
+          rules = [
+            {
+              alert = "HighAPIServer4xxRate"
+              expr  = "sum(rate(apiserver_request_total{code=~\"4..\"}[5m])) > 5"
+              for   = "2m"
+              labels      = { severity = "warning" }
+              annotations = {
+                summary     = "API Server 4xx 오류율 높음"
+                description = "API Server 4xx 요청 rate가 5 req/s 초과"
+              }
+            },
+            {
+              alert = "HighPodRestartCount"
+              expr  = "sum(increase(kube_pod_container_status_restarts_total[1h])) by (namespace, pod) > 5"
+              for   = "5m"
+              labels      = { severity = "warning" }
+              annotations = {
+                summary     = "Pod 재시작 횟수 높음"
+                description = "{{ $labels.namespace }}/{{ $labels.pod }} 재시작 1시간 내 5회 초과"
+              }
+            },
+            {
+              alert = "TooManyPendingPods"
+              expr  = "sum(kube_pod_status_phase{phase=\"Pending\"}) by (namespace) >= 3"
+              for   = "5m"
+              labels      = { severity = "critical" }
+              annotations = {
+                summary     = "Pending Pod 다수 감지"
+                description = "{{ $labels.namespace }} 네임스페이스에 Pending Pod 3개 이상"
+              }
+            },
+            {
+              alert = "HighCPUQuotaUsage"
+              expr  = "kube_resourcequota{resource=\"requests.cpu\",type=\"used\"} / kube_resourcequota{resource=\"requests.cpu\",type=\"hard\"} > 0.9"
+              for   = "5m"
+              labels      = { severity = "warning" }
+              annotations = {
+                summary     = "CPU Quota 90% 초과"
+                description = "{{ $labels.namespace }} CPU quota 사용률 90% 초과"
+              }
+            },
+            {
+              alert = "HighMemoryQuotaUsage"
+              expr  = "kube_resourcequota{resource=\"requests.memory\",type=\"used\"} / kube_resourcequota{resource=\"requests.memory\",type=\"hard\"} > 0.9"
+              for   = "5m"
+              labels      = { severity = "warning" }
+              annotations = {
+                summary     = "Memory Quota 90% 초과"
+                description = "{{ $labels.namespace }} Memory quota 사용률 90% 초과"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  depends_on = [helm_release.kube_prometheus_stack]
+}

--- a/modules/k8s-base/dashboards/security-overview.json
+++ b/modules/k8s-base/dashboards/security-overview.json
@@ -1,0 +1,144 @@
+{
+  "title": "EKS Security Overview",
+  "uid": "eks-security-overview",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "API Server 4xx 요청 rate (5m)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(apiserver_request_total{code=~\"4..\"}[5m])) by (code, verb)",
+          "legendFormat": "{{code}} {{verb}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "API Server 요청 rate (verb별)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(apiserver_request_total[5m])) by (verb)",
+          "legendFormat": "{{verb}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 3,
+      "title": "네임스페이스별 Pod 재시작 (1h)",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(increase(kube_pod_container_status_restarts_total[1h])) by (namespace, pod) > 0",
+          "legendFormat": "",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "renameByName": { "namespace": "네임스페이스", "pod": "Pod", "Value": "재시작 횟수" } } }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Pending Pod 수 (네임스페이스별)",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(kube_pod_status_phase{phase=\"Pending\"}) by (namespace)",
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "ResourceQuota CPU 사용률",
+      "type": "gauge",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "kube_resourcequota{resource=\"requests.cpu\", type=\"used\"} / kube_resourcequota{resource=\"requests.cpu\", type=\"hard\"}",
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "ResourceQuota Memory 사용률",
+      "type": "gauge",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "kube_resourcequota{resource=\"requests.memory\", type=\"used\"} / kube_resourcequota{resource=\"requests.memory\", type=\"hard\"}",
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -206,7 +206,18 @@ resource "helm_release" "kube_prometheus_stack" {
         }
       }
       alertmanager = {
-        enabled = false
+        enabled = true
+        alertmanagerSpec = {
+          storage = {
+            volumeClaimTemplate = {
+              spec = {
+                storageClassName = kubernetes_storage_class_v1.encrypted_gp3.metadata[0].name
+                accessModes      = ["ReadWriteOnce"]
+                resources        = { requests = { storage = "2Gi" } }
+              }
+            }
+          }
+        }
       }
     })
   ]

--- a/modules/k8s-base/main.tf
+++ b/modules/k8s-base/main.tf
@@ -147,3 +147,92 @@ resource "helm_release" "external_secrets" {
 
   depends_on = [helm_release.aws_load_balancer_controller]
 }
+
+# ---------------------------------------------------------------------------
+# kube-prometheus-stack
+#   Prometheus + Grafana + kube-state-metrics + node-exporter 를 한 번에 배포.
+#   Grafana sidecar가 grafana_dashboard: "1" 레이블이 붙은 ConfigMap을 자동 감지한다.
+# ---------------------------------------------------------------------------
+resource "helm_release" "kube_prometheus_stack" {
+  name             = "kube-prometheus-stack"
+  namespace        = var.prometheus_namespace
+  create_namespace = true
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "kube-prometheus-stack"
+  version          = var.prometheus_chart_version
+  timeout          = var.helm_release_timeout_seconds
+  atomic           = true
+  cleanup_on_fail  = true
+  wait             = true
+
+  values = [
+    yamlencode({
+      prometheus = {
+        prometheusSpec = {
+          retention = "7d"
+          resources = {
+            requests = { cpu = "250m", memory = "512Mi" }
+            limits   = { cpu = "500m", memory = "1Gi" }
+          }
+          storageSpec = {
+            volumeClaimTemplate = {
+              spec = {
+                storageClassName = kubernetes_storage_class_v1.encrypted_gp3.metadata[0].name
+                accessModes      = ["ReadWriteOnce"]
+                resources        = { requests = { storage = "20Gi" } }
+              }
+            }
+          }
+        }
+      }
+      grafana = {
+        adminPassword = var.grafana_admin_password
+        persistence = {
+          enabled          = true
+          storageClassName = kubernetes_storage_class_v1.encrypted_gp3.metadata[0].name
+          size             = "5Gi"
+        }
+        sidecar = {
+          dashboards = {
+            enabled         = true
+            label           = "grafana_dashboard"
+            searchNamespace = "ALL"
+          }
+        }
+        ingress = {
+          enabled          = true
+          ingressClassName = "nginx"
+          hosts            = ["grafana.${var.cluster_name}.local"]
+        }
+      }
+      alertmanager = {
+        enabled = false
+      }
+    })
+  ]
+
+  depends_on = [
+    helm_release.ingress_nginx,
+    kubernetes_storage_class_v1.encrypted_gp3,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Grafana 보안 대시보드 ConfigMap
+#   Grafana sidecar가 이 ConfigMap을 자동으로 감지해 대시보드를 등록한다.
+# ---------------------------------------------------------------------------
+resource "kubernetes_config_map" "grafana_security_dashboard" {
+  metadata {
+    name      = "grafana-security-dashboard"
+    namespace = var.prometheus_namespace
+    labels = {
+      grafana_dashboard = "1"
+    }
+  }
+
+  data = {
+    "security-overview.json" = file("${path.module}/dashboards/security-overview.json")
+  }
+
+  depends_on = [helm_release.kube_prometheus_stack]
+}

--- a/modules/k8s-base/outputs.tf
+++ b/modules/k8s-base/outputs.tf
@@ -47,3 +47,13 @@ output "encrypted_storage_class_name" {
   description = "Encrypted gp3 StorageClass name for EBS-backed workload PVCs."
   value       = kubernetes_storage_class_v1.encrypted_gp3.metadata[0].name
 }
+
+output "prometheus_release_name" {
+  description = "Helm release name for kube-prometheus-stack."
+  value       = helm_release.kube_prometheus_stack.name
+}
+
+output "prometheus_namespace" {
+  description = "Namespace where kube-prometheus-stack is deployed."
+  value       = helm_release.kube_prometheus_stack.namespace
+}

--- a/modules/k8s-base/variables.tf
+++ b/modules/k8s-base/variables.tf
@@ -96,3 +96,21 @@ variable "external_secrets_service_account_name" {
   type        = string
   default     = "external-secrets"
 }
+
+variable "prometheus_namespace" {
+  description = "Namespace used for the kube-prometheus-stack release."
+  type        = string
+  default     = "monitoring"
+}
+
+variable "prometheus_chart_version" {
+  description = "Pinned chart version for kube-prometheus-stack."
+  type        = string
+  default     = "70.4.2"
+}
+
+variable "grafana_admin_password" {
+  description = "Grafana admin password. Set via tfvars or environment variable (TF_VAR_grafana_admin_password)."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #49

## 무엇을 만들었나요? (What)
Stage 3의 대시보드 임계값을 기반으로 AlertManager와 PrometheusRule을 추가하여 이상치 자동 알림을 구성합니다.

**포함 내용**
- AlertManager 활성화 및 2Gi PVC 스토리지 설정
- PrometheusRule (eks-security-alerts) 추가
  - `HighAPIServer4xxRate` : 4xx 요청 rate 5 req/s 초과 시 경고
  - `HighPodRestartCount` : 1시간 내 Pod 재시작 5회 초과 시 경고
  - `TooManyPendingPods` : Pending Pod 3개 이상 시 critical
  - `HighCPUQuotaUsage` : CPU Quota 사용률 90% 초과 시 경고
  - `HighMemoryQuotaUsage` : Memory Quota 사용률 90% 초과 시 경고

## 왜 이렇게 만들었나요? (Why)
대시보드는 능동적으로 확인해야 하지만 알림은 이상치 발생 시 자동으로 감지한다
Stage 3 대시보드의 임계값을 그대로 PrometheusRule로 옮겨 사람이 화면을 보지 않아도 동일한 기준으로 탐지되도록 하기 위함

## 테스트
생략 
알람 설정만 해뒀고 아직 알람오는건 테스트 진행 안 함 
현재 환경 세팅이 안된 상태에서 진행한거라 추후 진행 예정

## 참고
Stage 1. #123 
Stage 2. #124 
Stage 3. #107 
Stage 4. #125
