### PR TITLE
[Feat] eBPF 기반 네트워크 이상 행위 탐지 활성화

### DIFF
--- a/manifests/labs/cilium-ebpf-observability/cilium-dns-fqdn-policy.yaml
+++ b/manifests/labs/cilium-ebpf-observability/cilium-dns-fqdn-policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-web-dns-and-github-fqdn-egress
+  labels:
+    training.k8rvis.io/lab: cilium-ebpf-observability
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toFQDNs:
+        - matchName: api.github.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/manifests/labs/cilium-ebpf-observability/cilium-http-l7-policy.yaml
+++ b/manifests/labs/cilium-ebpf-observability/cilium-http-l7-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-web-to-api-health-http
+  labels:
+    training.k8rvis.io/lab: cilium-ebpf-observability
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: web
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+          rules:
+            http:
+              - method: "GET"
+                path: "/healthz"

--- a/manifests/labs/cilium-ebpf-observability/cilium-values.yaml
+++ b/manifests/labs/cilium-ebpf-observability/cilium-values.yaml
@@ -1,0 +1,23 @@
+cni:
+  chainingMode: aws-cni
+  exclusive: false
+
+enableIPv4Masquerade: false
+routingMode: native
+
+hubble:
+  enabled: true
+  relay:
+    enabled: true
+  ui:
+    enabled: true
+  metrics:
+    enabled:
+      - dns:query;ignoreAAAA
+      - drop
+      - tcp
+      - flow
+      - http
+
+operator:
+  replicas: 1

--- a/manifests/labs/cilium-ebpf-observability/kustomization.yaml
+++ b/manifests/labs/cilium-ebpf-observability/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: team-d
+
+resources:
+  - network-policy-baseline.yaml
+  - cilium-dns-fqdn-policy.yaml
+  - cilium-http-l7-policy.yaml

--- a/manifests/labs/cilium-ebpf-observability/network-policy-baseline.yaml
+++ b/manifests/labs/cilium-ebpf-observability/network-policy-baseline.yaml
@@ -1,0 +1,125 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  labels:
+    training.k8rvis.io/lab: cilium-ebpf-observability
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  labels:
+    training.k8rvis.io/lab: cilium-ebpf-observability
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  labels:
+    training.k8rvis.io/lab: cilium-ebpf-observability
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-public-ingress-to-web
+  labels:
+    training.k8rvis.io/lab: cilium-ebpf-observability
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-web-to-api
+  labels:
+    training.k8rvis.io/lab: cilium-ebpf-observability
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: api
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-to-db
+  labels:
+    training.k8rvis.io/lab: cilium-ebpf-observability
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: db
+      ports:
+        - protocol: TCP
+          port: 6379
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-db-ingress-from-api
+  labels:
+    training.k8rvis.io/lab: cilium-ebpf-observability
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: db
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: api
+      ports:
+        - protocol: TCP
+          port: 6379


### PR DESCRIPTION
## Issue

closes #122 

## 무엇을 만들었는가

Cilium/Hubble 기반 네트워크 관찰 코드를 추가했다.

- Hubble 활성화 및 정책 적용, flow 관찰, rollback 절차
- Hubble relay/UI/metrics 활성화
- 표준 Kubernetes `NetworkPolicy` 기반 default deny 및 web/api/db 통신 허용 정책
- Cilium DNS/FQDN 기반 egress 정책 예제
- HTTP method/path 기반 L7 정책 예제

## 왜 만들었는가

기본 Kubernetes NetworkPolicy는 주로 L3/L4 수준의 제어에 머무르기 때문에, 운영 중 어떤 서비스가 누구와 어떤 프로토콜로 통신했는지를 빠르게 파악하기 어렵다.

Cilium과 Hubble을 사용하면 eBPF 기반 flow visibility를 확보할 수 있고, 필요 시 DNS/FQDN 및 HTTP L7 정책까지 확장할 수 있다.

## 취약점/미흡 상태 확인

적용 전에는 Cilium/Hubble 기반 flow visibility와 Cilium 정책 리소스가 없거나 동작하지 않아야 한다.

```
# Cilium 설치 여부 확인
cilium status

# Hubble flow 관찰 가능 여부 확인
hubble status
hubble observe --namespace team-d

# Cilium CRD 존재 여부 확인
kubectl get crd ciliumnetworkpolicies.cilium.io

# 실습 정책 미적용 상태 확인
kubectl get networkpolicy -n team-d
kubectl get ciliumnetworkpolicy -n team-d

# 현재 렌더링될 실습 manifest 확인
kubectl kustomize manifests/labs/cilium-ebpf-observability
```

- cilium status 또는 hubble status가 실패한다.
- hubble observe로 namespace 단위 flow를 볼 수 없다.
- CiliumNetworkPolicy CRD가 없거나, team-d에 DNS/FQDN/L7 정책이 없다.
- 서비스 간 허용/차단 트래픽을 Hubble에서 추적할 수 없다.

## 적용 명령어

```
helm repo add cilium https://helm.cilium.io/
helm repo update

helm upgrade --install cilium cilium/cilium \
  --version 1.19.4 \
  --namespace kube-system \
  --values manifests/labs/cilium-ebpf-observability/cilium-values.yaml

kubectl rollout restart deployment/web -n team-d
kubectl rollout restart deployment/api -n team-d
kubectl rollout restart statefulset/db -n team-d

kubectl apply -k manifests/labs/cilium-ebpf-observability
```

## 적용 후 검증 명령어

```
# Cilium/Hubble 상태 확인
cilium status
hubble status

# 정책 리소스 확인
kubectl get networkpolicy -n team-d
kubectl get ciliumnetworkpolicy -n team-d

# flow 수집 확인
hubble observe --namespace team-d
hubble observe --namespace team-d --protocol http
hubble observe --namespace team-d --verdict DROPPED

# Hubble UI 확인
cilium hubble ui
```

## DNS/FQDN 및 HTTP L7 정책 검증

```
# web pod 이름 확인
WEB_POD=$(kubectl get pod -n team-d -l app.kubernetes.io/name=web -o jsonpath='{.items[0].metadata.name}')

# 허용된 FQDN 접근 확인
kubectl exec -n team-d "$WEB_POD" -- curl -I https://api.github.com

# 허용되지 않은 외부 FQDN 접근 차단 확인
kubectl exec -n team-d "$WEB_POD" -- curl -I https://example.com

# 허용된 HTTP path 확인
kubectl exec -n team-d "$WEB_POD" -- curl -i http://api/healthz

# 허용되지 않은 HTTP path 또는 method 차단 확인
kubectl exec -n team-d "$WEB_POD" -- curl -i http://api/
kubectl exec -n team-d "$WEB_POD" -- curl -X POST -i http://api/healthz
```