### PR TITLE
[Feat] Secret 감사 (Falco 추가)

### DIFF
--- a/environments/platform/main.tf
+++ b/environments/platform/main.tf
@@ -165,6 +165,16 @@ module "namespaces" {
   depends_on = [module.k8s_base]
 }
 
+module "falco" {
+  source = "../../modules/falco"
+
+  helm_release_timeout_seconds = var.helm_release_timeout_seconds
+  falco_namespace              = var.falco_namespace
+  falco_chart_version          = var.falco_chart_version
+
+  depends_on = [module.k8s_base]
+}
+
 module "argocd" {
   source = "../../modules/argocd"
 
@@ -180,6 +190,7 @@ module "argocd" {
 
   depends_on = [
     module.k8s_base,
+    module.falco,
     module.namespaces,
     aws_eks_pod_identity_association.external_secrets,
   ]

--- a/environments/platform/variables.tf
+++ b/environments/platform/variables.tf
@@ -125,6 +125,18 @@ variable "external_secrets_secret_arns" {
   default     = ["arn:aws:secretsmanager:*:*:secret:/eks-secure-infra/app/*"]
 }
 
+variable "falco_namespace" {
+  description = "Namespace used for the Falco release."
+  type        = string
+  default     = "falco"
+}
+
+variable "falco_chart_version" {
+  description = "Pinned chart version for Falco."
+  type        = string
+  default     = "8.0.5"
+}
+
 variable "argocd_namespace" {
   description = "Namespace used for the ArgoCD installation."
   type        = string

--- a/modules/falco/.terraform.lock.hcl
+++ b/modules/falco/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:rsqAO9oKyDMLiysQqrWEzf9CNtU9NJtwEGk7bSItC9g=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/modules/falco/main.tf
+++ b/modules/falco/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+  }
+}
+
+locals {
+  falco_values       = yamldecode(file("${path.module}/values/falco-values.yaml"))
+  falco_custom_rules = file("${path.module}/rules/falco-custom-rules.yaml")
+}
+
+resource "helm_release" "falco" {
+  name             = "falco"
+  namespace        = var.falco_namespace
+  create_namespace = true
+  repository       = "https://falcosecurity.github.io/charts"
+  chart            = "falco"
+  version          = var.falco_chart_version
+  timeout          = var.helm_release_timeout_seconds
+  atomic           = true
+  cleanup_on_fail  = true
+  wait             = true
+
+  values = [
+    yamlencode(merge(local.falco_values, {
+      customRules = {
+        "falco-custom-rules.yaml" = local.falco_custom_rules
+      }
+    }))
+  ]
+}

--- a/modules/falco/rules/falco-custom-rules.yaml
+++ b/modules/falco/rules/falco-custom-rules.yaml
@@ -1,0 +1,135 @@
+- list: k8s_secret_mount_prefixes
+  items: [/var/run/secrets, /etc/secrets, /run/secrets, /mnt/secrets, /opt/secrets]
+
+- list: k8s_serviceaccount_token_prefixes
+  items: [/var/run/secrets/kubernetes.io/serviceaccount]
+
+- list: secret_file_reader_binaries
+  items: [cat, less, more, head, tail, grep, egrep, fgrep, awk, sed, strings, base64, xxd, od, hexdump, jq, vi, vim, nano, busybox]
+
+- list: secret_path_discovery_binaries
+  items: [ls, find, stat, tree, dirname, readlink]
+
+- list: container_shell_binaries
+  items: [sh, bash, dash, ash, zsh, ksh]
+
+- macro: k8s_runtime_secret_path
+  condition: >
+    (
+      fd.name pmatch (k8s_secret_mount_prefixes) or
+      fs.path.name pmatch (k8s_secret_mount_prefixes)
+    )
+
+- macro: k8s_serviceaccount_token_path
+  condition: >
+    (
+      fd.name pmatch (k8s_serviceaccount_token_prefixes) or
+      fs.path.name pmatch (k8s_serviceaccount_token_prefixes)
+    )
+
+- macro: workload_secret_volume_path
+  condition: >
+    k8s_runtime_secret_path and
+    not k8s_serviceaccount_token_path
+
+- macro: container_shell_process
+  condition: proc.name in (container_shell_binaries)
+
+- macro: process_environment_file
+  condition: >
+    (
+      fd.name contains "/proc/" and fd.name endswith "/environ"
+    )
+
+- rule: Manual Secret File Inspection In Container
+  desc: Detect command-line tools manually reading Kubernetes Secret volume files from within a container
+  condition: >
+    open_read and
+    container and
+    k8s_runtime_secret_path and
+    proc.name in (secret_file_reader_binaries)
+  output: >
+    Manual secret file inspection detected
+    (evt.type=%evt.type user=%user.name command=%proc.cmdline parent=%proc.pname
+    file=%fd.name normalized_file=%fs.path.name container=%container.name
+    image=%container.image.repository k8s.ns=%k8s.ns.name pod=%k8s.pod.name)
+  priority: WARNING
+  tags: [container, k8s, secret, data_protection, manual_access]
+
+- rule: Read Workload Secret Volume From Container
+  desc: Detect read access to workload-mounted Secret paths excluding the default service account token path
+  condition: >
+    open_read and
+    container and
+    workload_secret_volume_path
+  output: >
+    Workload secret volume read detected
+    (evt.type=%evt.type user=%user.name command=%proc.cmdline parent=%proc.pname
+    file=%fd.name normalized_file=%fs.path.name container=%container.name
+    image=%container.image.repository k8s.ns=%k8s.ns.name pod=%k8s.pod.name)
+  priority: NOTICE
+  tags: [container, k8s, secret, data_protection, file_access]
+
+- rule: Read Kubernetes ServiceAccount Token From Container
+  desc: Detect read access to a Kubernetes projected service account token from within a container
+  condition: >
+    open_read and
+    container and
+    k8s_serviceaccount_token_path
+  output: >
+    Kubernetes service account token read detected
+    (evt.type=%evt.type user=%user.name command=%proc.cmdline parent=%proc.pname
+    file=%fd.name normalized_file=%fs.path.name container=%container.name
+    image=%container.image.repository k8s.ns=%k8s.ns.name pod=%k8s.pod.name)
+  priority: NOTICE
+  tags: [container, k8s, serviceaccount, token, data_protection]
+
+- rule: Secret Path Discovery In Container
+  desc: Detect directory discovery commands targeting common Secret mount paths inside a container
+  condition: >
+    spawned_process and
+    container and
+    proc.name in (secret_path_discovery_binaries) and
+    (
+      proc.args contains "/var/run/secrets" or
+      proc.args contains "/etc/secrets" or
+      proc.args contains "/run/secrets" or
+      proc.args contains "/mnt/secrets" or
+      proc.args contains "/opt/secrets"
+    )
+  output: >
+    Secret path discovery command detected
+    (evt.type=%evt.type user=%user.name command=%proc.cmdline parent=%proc.pname
+    container=%container.name image=%container.image.repository
+    k8s.ns=%k8s.ns.name pod=%k8s.pod.name)
+  priority: NOTICE
+  tags: [container, k8s, secret, data_protection, discovery]
+
+- rule: Process Environment File Read In Container
+  desc: Detect command-line tools reading /proc environment files that may expose env-injected secrets
+  condition: >
+    open_read and
+    container and
+    process_environment_file and
+    proc.name in (secret_file_reader_binaries)
+  output: >
+    Process environment file read detected
+    (evt.type=%evt.type user=%user.name command=%proc.cmdline parent=%proc.pname
+    file=%fd.name container=%container.name image=%container.image.repository
+    k8s.ns=%k8s.ns.name pod=%k8s.pod.name)
+  priority: WARNING
+  tags: [container, env, secret, data_protection]
+
+- rule: Shell Spawned In Container
+  desc: Detect shell execution inside a container
+  condition: >
+    spawned_process and
+    container and
+    container_shell_process
+  output: >
+    Shell spawned in container
+    (evt.type=%evt.type user=%user.name command=%proc.cmdline parent=%proc.pname terminal=%proc.tty
+    container=%container.name image=%container.image.repository
+    k8s.ns=%k8s.ns.name pod=%k8s.pod.name)
+  priority: NOTICE
+  tags: [container, shell, runtime]

--- a/modules/falco/values/falco-values.yaml
+++ b/modules/falco/values/falco-values.yaml
@@ -1,0 +1,7 @@
+falco:
+  json_output: true
+  buffered_outputs: false
+  stdout_output:
+    enabled: true
+  syslog_output:
+    enabled: false

--- a/modules/falco/variables.tf
+++ b/modules/falco/variables.tf
@@ -1,0 +1,17 @@
+variable "helm_release_timeout_seconds" {
+  description = "Timeout in seconds applied to the Falco helm release."
+  type        = number
+  default     = 600
+}
+
+variable "falco_namespace" {
+  description = "Namespace used for the Falco release."
+  type        = string
+  default     = "falco"
+}
+
+variable "falco_chart_version" {
+  description = "Pinned chart version for Falco."
+  type        = string
+  default     = "8.0.5"
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #105 

## 무엇을 만들었나요? (What)
- Falco를 Terraform helm_release로 배포하는 falco 모듈을 추가했다.
- Pod 내부 런타임 Secret 접근 탐지용 custom rule을 추가했다.
    - Secret mount path 수동 조회 탐지
    - workload Secret volume read 탐지
    - Kubernetes ServiceAccount token read 탐지
    - Secret mount path 탐색 명령 탐지
    - `/proc/*/environ` 조회 탐지
    - 컨테이너 내부 shell 실행 탐지

## 왜 이렇게 만들었나요? (Why)
- #106에서 구성한 Secret 감사는 EKS audit/authenticator 로그와 CloudTrail을 통해 Kubernetes API 또는 AWS API 기반 Secret 접근을 추적하지만 Pod 내부에 이미 주입된 Secret 파일을 프로세스가 직접 읽거나, 컨테이너 shell에서 Secret 경로를 조회하는 행위 등은 API 감사만으로 확인하기 어렵다.
- Falco를 추가하여 control plane/API 감사로 보기 어려운 data plane/runtime 영역의 Secret 접근 행위를 보완하고자 하였다.

## 테스트
```bash
kubectl get pods -n falco -o wide
kubectl get daemonset -n falco
kubectl get configmap -n falco falco-rules -o yaml | Select-String "Manual Secret File Inspection"
```
이를 통해 Falco가 잘 적용되었는지를 확인한다. 

테스트용 Pod와 Secret을 배포한 후, 아래와 같이 의도적으로 Falco rule을 트리거 하도록 하여 Falco 로그 결과를 확인하여 탐지가 잘 되는지 확인하고자 한다. 
- kubectl exec -n falco-test falco-secret-test -- sh
- kubectl exec -n falco-test falco-secret-test -- ls /etc/secrets
- kubectl exec -n falco-test falco-secret-test -- cat /etc/secrets/password
- kubectl exec -n falco-test falco-secret-test -- cat /var/run/secrets/kubernetes.io/serviceaccount/token
- kubectl exec -n falco-test falco-secret-test -- sh -c "cat /proc/1/environ > /dev/null"
- kubectl logs -n falco -l app.kubernetes.io/name=falco --since=10m |
  Select-String "secret|Secret|Shell|environment|service account"

## 참고
- #106의 API 기반 Secret 감사 를 대체하는 것이 아닌 보완하고자 하는 항목이다. 
